### PR TITLE
feat(auth): 認証ミドルウェアを追加 (#72)

### DIFF
--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	// Cookie名
+	SessionCookieName = "session_token"
+	// Gin Contextに保存するキー
+	ContextKeyUser = "currentUser"
+)
+
+// AuthMiddleware はセッションベースの認証ミドルウェア
+func AuthMiddleware(service *Service) gin.HandlerFunc { // gin.HandlerFuncにGinがcを自動で渡す
+	return func(c *gin.Context) {
+		// 1. Cookieからセッショントークンを取得
+		token, err := c.Cookie(SessionCookieName)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error": "認証が必要です",
+			})
+			return
+		}
+
+		// 2. トークンでセッションを検証し、ユーザー情報を取得
+		user, err := service.GetCurrentUser(c.Request.Context(), token)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error": "無効または期限切れのセッションです",
+			})
+			return
+		}
+
+		// 3. Gin Contextにユーザー情報をセット
+		c.Set(ContextKeyUser, user)
+
+		// 4. 次のハンドラーへ
+		c.Next()
+	}
+}
+
+// GetCurrentUserFromContext はGin Contextからユーザー情報を取得するヘルパー
+func GetCurrentUserFromContext(c *gin.Context) (*UserResponse, bool) {
+	value, exists := c.Get(ContextKeyUser)
+	if !exists {
+		return nil, false
+	}
+
+	user, ok := value.(*UserResponse)
+	if !ok {
+		return nil, false
+	}
+
+	return user, true
+}


### PR DESCRIPTION
## PR タイトル

```
feat(auth): 認証ミドルウェアの実装 #72
```

## PR 本文

## 概要

Close #72

セッションベースの認証ミドルウェアを実装した。
Cookie からセッショントークンを取得・検証し、認証済みユーザー情報を Gin Context にセットする。

## 変更内容

### 追加ファイル
- `internal/auth/middleware.go`

### 実装内容

**`AuthMiddleware(service *Service) gin.HandlerFunc`**
- Cookie `session_token` からトークンを取得
- `service.GetCurrentUser` でセッション検証 + ユーザー取得
- 認証OKの場合、`c.Set("currentUser", user)` で Context にセット
- 認証NG（Cookie なし / 無効 / 期限切れ）の場合、401 を返して処理を中断

**`GetCurrentUserFromContext(c *gin.Context) (*UserResponse, bool)`**
- ハンドラーから型安全にユーザー情報を取り出すヘルパー関数

**定数**
- `SessionCookieName = "session_token"` — Cookie 名
- `ContextKeyUser = "currentUser"` — Context キー

## 使用方法

```
// 認証不要なルート

public := [[r.Group](http://r.group/)](http://r.Group)("/api/auth")

[[public.POST](http://public.post/)](http://public.POST)("/signup", handler.Signup)

[[public.POST](http://public.post/)](http://public.POST)("/login", handler.Login)

// 認証必要なルート

protected := [[r.Group](http://r.group/)](http://r.Group)("/api")

protected.Use(auth.AuthMiddleware(authService))

[[protected.POST](http://protected.post/)](http://protected.POST)("/auth/logout", handler.Logout)

protected.GET("/auth/me", [[handler.Me](http://handler.me/)](http://handler.Me))
```

## 認証フロー

```
リクエスト

↓

AuthMiddleware

├─ Cookie "session_token" なし → 401

├─ トークン無効 or 期限切れ  → 401

└─ 認証OK → c.Set("currentUser", user) → [[c.Next](http://c.next/)](http://c.Next)()
```

## 関連 Issue / PR

- #54 認証モデル・リポジトリ層の実装
- #61 認証サービス層の実装
- 次: 認証ハンドラー・ルーティングの実装
```