### PR TITLE
feat(auth): 認証ハンドラーの実装、ルーティング設定、リポジトリインターフェースの命名修正 (#73)

### DIFF
--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -1,0 +1,119 @@
+package auth
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Handler struct {
+	service *Service
+}
+
+func NewHandler(service *Service) *Handler {
+	return &Handler{service: service}
+}
+
+// Signup POST /api/auth/signup
+func (h *Handler) Signup(c *gin.Context) {
+	// 1. リクエストをパース
+	var req SignupRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "リクエストが不正です"})
+	}
+
+	// 2. サービス層を呼ぶ
+	user, token, err := h.service.Signup(c.Request.Context(), req)
+	if err != nil {
+		if err == ErrEmailAlreadyExists {
+			c.JSON(http.StatusConflict, gin.H{"error": "このメールアドレスは既に使用されています"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "サーバーエラーが発生しました"})
+		return
+	}
+
+	// 3. Cookieをセット
+	setSessionCookie(c, token)
+
+	// 4. レスポンスを返す
+	c.JSON(http.StatusCreated, user)
+}
+
+// Login POST /api/auth/login
+func (h *Handler) Login(c *gin.Context) {
+	var req LoginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "リクエストが不正です"})
+		return
+	}
+
+	user, token, err := h.service.Login(c.Request.Context(), req)
+	if err != nil {
+		if err == ErrInvalidCredentials {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "メールアドレスまたはパスワードが正しくありません"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "サーバーエラーが発生しました"})
+		return
+	}
+
+	setSessionCookie(c, token)
+	c.JSON(http.StatusOK, user)
+}
+
+// Logout POST /api/auth/logout
+func (h *Handler) Logout(c *gin.Context) {
+	token, err := c.Cookie(SessionCookieName)
+	if err != nil {
+		// Cookie がなくてもログアウト成功として返す
+		c.JSON(http.StatusOK, gin.H{"message": "ログアウトしました"})
+		return
+	}
+
+	if err := h.service.Logout(c.Request.Context(), token); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "サーバーエラーが発生しました"})
+		return
+	}
+
+	clearSessionCookie(c)
+	c.JSON(http.StatusOK, gin.H{"message": "ログアウトしました"})
+}
+
+// Me GET /api/auth/me
+func (h *Handler) Me(c *gin.Context) {
+	user, ok := GetCurrentUserFromContext(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "認証が必要です"})
+		return
+	}
+
+	c.JSON(http.StatusOK, user)
+}
+
+// setSessionCookie はレスポンスにセッションCookieをセットする
+func setSessionCookie(c *gin.Context, token string) {
+	c.SetCookie(
+		SessionCookieName,
+		token,
+		int(24*time.Hour.Seconds()), // 24時間
+		"/",
+		"",    // domain（本番では設定）
+		false, // secure（本番ではtrue）
+		true,  // httpOnly
+	)
+}
+
+// clearSessionCookie はセッションCookieを削除する
+func clearSessionCookie(c *gin.Context) {
+	c.SetCookie(
+		SessionCookieName,
+		"",
+		-1,
+		"/",
+		"",
+		false,
+		true,
+	)
+}

--- a/backend/internal/auth/repository.go
+++ b/backend/internal/auth/repository.go
@@ -17,5 +17,5 @@ type Repository interface {
 	CreateSession(ctx context.Context, session *Session) error
 	GetSessionByToken(ctx context.Context, token string) (*Session, error)
 	DeleteSessionByToken(ctx context.Context, token string) error
-	DeleteSessionsByUserID(ctx context.Context, userID uuid.UUID) error
+	DeleteSessionByUserID(ctx context.Context, userID uuid.UUID) error
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -7,33 +7,45 @@
 package main
 
 import (
-	_ "backend/docs"
 	"database/sql"
 	"log"
 	"net/http"
 	"os"
 
+	_ "backend/docs"
+
+	"backend/internal/auth"
 	"backend/internal/chat/websocket"
 	"backend/internal/task"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
 func main() {
+	// DB接続
 	db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))
 	if err != nil {
 		log.Fatalf("failed to open db: %v", err)
 	}
 	defer db.Close()
 
+	// *sql.DBをsqlx.DBにラップ（authで使用）
+	sqlxDB := sqlx.NewDb(db, "postgres")
+
+	// 依存関係の組み立て（DI）
+	authRepo := auth.NewPostgresRepository(sqlxDB)
+	authService := auth.NewService(authRepo)
+	authHandler := auth.NewHandler(authService)
 	taskRepo := task.NewPostgresRepository(db)
 	taskSvc := task.NewService(taskRepo)
 	taskHandler := task.NewHandler(taskSvc)
 
+	// Ginルーター
 	r := gin.Default()
 
 	// 開発中はNext(3000)から叩くのでCORS許可
@@ -44,6 +56,21 @@ func main() {
 	}))
 
 	r.GET("/health", healthHandler)
+
+	// 認証不要
+	public := r.Group("/api/auth")
+	{
+		public.POST("/signup", authHandler.Signup)
+		public.POST("/login", authHandler.Login)
+	}
+
+	// 認証必要
+	protected := r.Group("/api")
+	protected.Use(auth.AuthMiddleware(authService))
+	{
+		protected.POST("/auth/logout", authHandler.Logout)
+		protected.GET("/auth/me", authHandler.Me)
+	}
 
 	hub := websocket.NewHub()
 	go hub.Run()


### PR DESCRIPTION
---

**タイトル：**

```
feat(auth): 認証ハンドラーの実装とルーティング設定 #73
```

---

**本文：**

## 概要

Issue #73 の対応。認証ハンドラー（signup / login / logout / me）の実装と、
main.go へのルーティング統合を行った。
また、sqlx を導入し repository_postgres.go のDB接続を `*sql.DB` → `sqlx.DB` に移行した。

## 変更ファイル

- `backend/internal/auth/handler.go`（新規）：認証ハンドラー実装
- `backend/internal/auth/repository.go`：インターフェースのメソッド名修正（`DeleteSessionsByUserID` → `DeleteSessionByUserID`）
- `backend/main.go`：DI組み立て・ルーティング追加・sqlxラップ

## 実装内容

### handler.go

| ハンドラー | メソッド | パス | 認証 |
|---|---|---|---|
| Signup | POST | `/api/auth/signup` | 不要 |
| Login | POST | `/api/auth/login` | 不要 |
| Logout | POST | `/api/auth/logout` | 必要 |
| Me | GET | `/api/auth/me` | 必要 |

- セッションCookieの付与・削除は `setSessionCookie` / `clearSessionCookie` で共通化
- `AuthMiddleware` で保護されたルートは `/api` グループに配置

### sqlx 導入

```

sqlxDB := sqlx.NewDb(db, "postgres")

authRepo := auth.NewPostgresRepository(sqlxDB)

```

`sql.Open` で取得した `*sql.DB` を `sqlx.NewDb` でラップすることで、
既存の `task` など他パッケージへの影響ゼロで sqlx を導入。

## 動作確認

```

# ユーザー登録

curl -X POST http://localhost:8080/api/auth/signup \

-H "Content-Type: application/json" \

-d '{"email":"[[test@example.com](mailto:test@example.com)](mailto:test@example.com)","password":"password123","display_name":"テストユーザー"}' \

-c cookie.txt

# → 201 Created / session_token Cookie がセットされる

# 認証確認

curl http://localhost:8080/api/auth/me -b cookie.txt

# → 200 OK / ユーザー情報が返る

# ログアウト

curl -X POST http://localhost:8080/api/auth/logout -b cookie.txt

# → 200 OK / session_token Cookie が削除される

# ログアウト後の認証確認

curl http://localhost:8080/api/auth/me -b cookie.txt

# → 401 Unauthorized / "無効または期限切れのセッションです"

# ログイン

curl -X POST http://localhost:8080/api/auth/login \

-H "Content-Type: application/json" \

-d '{"email":"[[test@example.com](mailto:test@example.com)](mailto:test@example.com)","password":"password123"}' \

-c cookie.txt

# → 200 OK / 新しい session_token Cookie がセットされる

```

すべて期待通りのレスポンスを確認済み。

## 関連 Issue

- Closes #73
- 依存: #54（model / repository）, #61（service）, #72（middleware）
```