### PR TITLE
feat(db): バディ・チャット・通知テーブルのマイグレーションを追加

### DIFF
--- a/backend/db/migrations/000003_buddy.down.sql
+++ b/backend/db/migrations/000003_buddy.down.sql
@@ -1,0 +1,16 @@
+DROP INDEX IF EXISTS idx_friend_relationships_user2;
+DROP INDEX IF EXISTS idx_friend_relationships_user1;
+DROP TABLE IF EXISTS friend_relationships;
+
+DROP INDEX IF EXISTS idx_buddy_relationships_ends_at;
+DROP INDEX IF EXISTS idx_buddy_relationships_user2;
+DROP INDEX IF EXISTS idx_buddy_relationships_user1;
+DROP TABLE IF EXISTS buddy_relationships;
+
+DROP TABLE IF EXISTS matching_queue;
+
+DROP TRIGGER IF EXISTS trigger_buddy_profiles_updated_at ON buddy_profiles;
+DROP TABLE IF EXISTS buddy_profiles;
+
+ALTER TABLE action_items
+    DROP CONSTRAINT IF EXISTS fk_action_items_user_id;

--- a/backend/db/migrations/000003_buddy.up.sql
+++ b/backend/db/migrations/000003_buddy.up.sql
@@ -1,0 +1,68 @@
+-- action_items に user_id の外部キー制約を追加
+ALTER TABLE action_items
+    ADD CONSTRAINT fk_action_items_user_id
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+-- buddy_profiles: マッチング条件の設定（ユーザーごとに1レコード）
+CREATE TABLE buddy_profiles (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id      UUID NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+    bio          TEXT,
+    goal_types   TEXT[] NOT NULL DEFAULT '{}',
+    active_times TEXT[] NOT NULL DEFAULT '{}',
+    created_at   TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TRIGGER trigger_buddy_profiles_updated_at
+    BEFORE UPDATE ON buddy_profiles
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- matching_queue: バディを探しているユーザーの待機列
+CREATE TABLE matching_queue (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+    status     VARCHAR(20) NOT NULL DEFAULT 'waiting'
+               CHECK (status IN ('waiting', 'matched', 'cancelled')),
+    joined_at  TIMESTAMP NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMP NOT NULL DEFAULT NOW() + INTERVAL '7 days'
+);
+
+-- buddy_relationships: マッチング成立したバディペア（1週間限定）
+-- user_id_1 < user_id_2 の制約で同一ペアの重複を防ぐ
+CREATE TABLE buddy_relationships (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id_1  UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    user_id_2  UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status     VARCHAR(20) NOT NULL DEFAULT 'active'
+               CHECK (status IN ('active', 'ended')),
+    matched_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    ends_at    TIMESTAMP NOT NULL DEFAULT NOW() + INTERVAL '7 days',
+    ended_at   TIMESTAMP,
+    UNIQUE (user_id_1, user_id_2),
+    CHECK (user_id_1 < user_id_2)
+);
+
+CREATE INDEX idx_buddy_relationships_user1
+    ON buddy_relationships (user_id_1);
+CREATE INDEX idx_buddy_relationships_user2
+    ON buddy_relationships (user_id_2);
+CREATE INDEX idx_buddy_relationships_ends_at
+    ON buddy_relationships (ends_at)
+    WHERE status = 'active';
+
+-- friend_relationships: バディ期間終了後に成立する長期的な関係
+CREATE TABLE friend_relationships (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id_1             UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    user_id_2             UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    buddy_relationship_id UUID REFERENCES buddy_relationships(id) ON DELETE SET NULL,
+    created_at            TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id_1, user_id_2),
+    CHECK (user_id_1 < user_id_2)
+);
+
+CREATE INDEX idx_friend_relationships_user1
+    ON friend_relationships (user_id_1);
+CREATE INDEX idx_friend_relationships_user2
+    ON friend_relationships (user_id_2);

--- a/backend/db/migrations/000004_chat.down.sql
+++ b/backend/db/migrations/000004_chat.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_messages_room_id_created_at;
+DROP TABLE IF EXISTS messages;
+
+DROP INDEX IF EXISTS idx_room_members_user_id;
+DROP TABLE IF EXISTS room_members;
+
+DROP TABLE IF EXISTS rooms;

--- a/backend/db/migrations/000004_chat.up.sql
+++ b/backend/db/migrations/000004_chat.up.sql
@@ -1,0 +1,29 @@
+-- rooms: チャットルーム
+-- buddy_relationship_id が NULL の場合はフレンド間のルーム
+CREATE TABLE rooms (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    buddy_relationship_id UUID REFERENCES buddy_relationships(id) ON DELETE SET NULL,
+    created_at            TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- room_members: ルームの参加者
+CREATE TABLE room_members (
+    room_id   UUID NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+    user_id   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    joined_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (room_id, user_id)
+);
+
+CREATE INDEX idx_room_members_user_id ON room_members (user_id);
+
+-- messages: チャットメッセージ
+CREATE TABLE messages (
+    id         BIGSERIAL PRIMARY KEY,
+    room_id    UUID NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+    sender_id  UUID NOT NULL REFERENCES users(id),
+    content    TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_messages_room_id_created_at
+    ON messages (room_id, created_at DESC);

--- a/backend/db/migrations/000005_notifications.down.sql
+++ b/backend/db/migrations/000005_notifications.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_notifications_user_id_created_at;
+DROP INDEX IF EXISTS idx_notifications_user_id_is_read;
+DROP TABLE IF EXISTS notifications;

--- a/backend/db/migrations/000005_notifications.up.sql
+++ b/backend/db/migrations/000005_notifications.up.sql
@@ -1,0 +1,20 @@
+-- notifications: アプリ内通知（現フェーズはポップアップのみ）
+CREATE TABLE notifications (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    type       VARCHAR(50) NOT NULL
+               CHECK (type IN ('action_item_reminder', 'match_found', 'new_message', 'buddy_ended')),
+    title      VARCHAR(255) NOT NULL,
+    body       TEXT,
+    is_read    BOOLEAN NOT NULL DEFAULT FALSE,
+    metadata   JSONB,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- 未読通知の取得に使う
+CREATE INDEX idx_notifications_user_id_is_read
+    ON notifications (user_id, is_read);
+
+-- 通知一覧の新着順ソートに使う
+CREATE INDEX idx_notifications_user_id_created_at
+    ON notifications (user_id, created_at DESC);


### PR DESCRIPTION
## 概要

バディマッチング・チャット・通知機能に必要なDBテーブルを追加するマイグレーションファイル（000003〜000005）を作成しました。

## 変更内容

### 000003_buddy
- `action_items` に `user_id` の外部キー制約を追加
- `buddy_profiles` テーブルを作成（マッチング条件の設定）
- `matching_queue` テーブルを作成（バディ待機列）
- `buddy_relationships` テーブルを作成（マッチング成立ペア・1週間限定）
- `friend_relationships` テーブルを作成（バディ期間終了後の長期関係）

### 000004_chat
- `rooms` テーブルを作成（チャットルーム）
- `room_members` テーブルを作成（ルーム参加者）
- `messages` テーブルを作成（チャットメッセージ・BIGSERIAL）

### 000005_notifications
- `notifications` テーブルを作成（アプリ内通知）

## 設計上のポイント

- `buddy_relationships` / `friend_relationships` は `user_id_1 < user_id_2` の CHECK 制約で同一ペアの重複を防止
- `buddy_relationships.ends_at` に部分インデックス（`WHERE status = 'active'`）を設定し、アクティブなバディの期限切れ検索を最適化
- `messages` は大量レコードを想定し主キーを `BIGSERIAL` に設定
- `notifications.metadata` は `JSONB` 型で通知の種別ごとの追加データに柔軟に対応
- `buddy_profiles` の `updated_at` は既存の `update_updated_at()` トリガーを再利用

## 動作確認

- [ ] `make migrate-up` で正常に適用されること
- [ ] `make migrate-down` で正常にロールバックされること
- [ ] `make db-tables` でテーブルが作成されていること

## 関連 Issue

Closes #83