### PR TITLE
feat(cors): CORS設定の環境変数化・Cookie本番対応

### DIFF
--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -94,14 +95,20 @@ func (h *Handler) Me(c *gin.Context) {
 
 // setSessionCookie はレスポンスにセッションCookieをセットする
 func setSessionCookie(c *gin.Context, token string) {
+	secure := os.Getenv("GIN_MODE") == "release"
+	if secure {
+		c.SetSameSite(http.SameSiteNoneMode)
+	} else {
+		c.SetSameSite(http.SameSiteLaxMode)
+	}
 	c.SetCookie(
 		SessionCookieName,
 		token,
 		int(24*time.Hour.Seconds()), // 24時間
 		"/",
-		"",    // domain（本番では設定）
-		false, // secure（本番ではtrue）
-		true,  // httpOnly
+		"",     // domain（本番では設定）
+		secure, // secure（本番ではtrue）
+		true,   // httpOnly
 	)
 }
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -64,8 +64,12 @@ func main() {
 	r := gin.Default()
 
 	// 開発中はNext(3000)から叩くのでCORS許可
+	corsOrigin := os.Getenv("CORS_ORIGIN")
+	if corsOrigin == "" {
+		corsOrigin = "http://localhost:3000" // ローカル開発用デフォルト
+	}
 	r.Use(cors.New(cors.Config{
-		AllowOrigins:     []string{"http://localhost:3000"},
+		AllowOrigins:     []string{corsOrigin},
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Origin", "Content-Type", "Authorization"},
 		AllowCredentials: true,


### PR DESCRIPTION
- CORS_ORIGINからフロントのオリジンを読み取るように変更
- 本番環境（GIN_MODE=release）でCookieのSecure=true, SameSite=Noneに設定
- ローカル開発ではSameSite=Lax, Secure=falseを維持