### PR TITLE
fix(auth): クロスドメイン環境でのセッションCookie対応

### DIFF
--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -38,8 +38,8 @@ func (h *Handler) Signup(c *gin.Context) {
 	// 3. Cookieをセット
 	setSessionCookie(c, token)
 
-	// 4. レスポンスを返す
-	c.JSON(http.StatusCreated, user)
+	// 4. レスポンスを返す（tokenをbodyにも含める）
+	c.JSON(http.StatusCreated, AuthResponse{Token: token, User: *user})
 }
 
 // Login POST /api/auth/login
@@ -61,7 +61,7 @@ func (h *Handler) Login(c *gin.Context) {
 	}
 
 	setSessionCookie(c, token)
-	c.JSON(http.StatusOK, user)
+	c.JSON(http.StatusOK, AuthResponse{Token: token, User: *user})
 }
 
 // Logout POST /api/auth/logout

--- a/backend/internal/auth/model.go
+++ b/backend/internal/auth/model.go
@@ -53,3 +53,9 @@ type UserResponse struct {
 	DisplayName string    `json:"display_name"`
 	CreatedAt   time.Time `json:"created_at"`
 }
+
+// AuthResponseはログイン・サインアップ時にクライアントに返すレスポンス
+type AuthResponse struct {
+	Token string       `json:"token"`
+	User  UserResponse `json:"user"`
+}

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -70,6 +70,7 @@ export function Header() {
       method: 'POST',
       credentials: 'include',
     })
+    document.cookie = 'session_token=; path=/; max-age=0'
     router.push('/login')
   }
 

--- a/frontend/src/features/auth/hooks/useAuth.ts
+++ b/frontend/src/features/auth/hooks/useAuth.ts
@@ -6,6 +6,15 @@ import type { LoginRequest, SignupRequest, UserResponse } from '../types'
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080'
 
+type AuthResponse = {
+  token: string
+  user: UserResponse
+}
+
+function setSessionCookie(token: string) {
+  document.cookie = `session_token=${token}; path=/; max-age=86400`
+}
+
 export function useAuth() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -25,7 +34,9 @@ export function useAuth() {
         setError(body.error ?? 'ユーザー登録に失敗しました')
         return null
       }
-      return (await res.json()) as UserResponse
+      const { token, user } = (await res.json()) as AuthResponse
+      setSessionCookie(token)
+      return user
     } catch {
       setError('ネットワークエラーが発生しました')
       return null
@@ -49,7 +60,9 @@ export function useAuth() {
         setError(body.error ?? 'ログインに失敗しました')
         return null
       }
-      return (await res.json()) as UserResponse
+      const { token, user } = (await res.json()) as AuthResponse
+      setSessionCookie(token)
+      return user
     } catch {
       setError('ネットワークエラーが発生しました')
       return null


### PR DESCRIPTION

## 概要
本番環境（Vercel + Railway）でログイン後にdashboardへ遷移できない問題を修正。

## 関連Issue
#101 

## 問題
- フロント（actbuddy-proto.vercel.app）とバック（actbuddy-proto-production.up.railway.app）が異なるドメイン
- バックエンドがSet-CookieしたsessiontokenはRailwayドメインに紐づく
- Next.jsのmiddleware.tsはVercelドメインのCookieしか読めない
- → middlewareがsession_tokenを検出できず、/dashboardから/loginにリダイレクトされる

## 解決策
ログイン/サインアップのレスポンスBodyにtokenを含め、フロント側でdocument.cookieを使って
Vercelドメインにsession_tokenをセットする。

## 変更内容

### Backend
- `model.go`: AuthResponse構造体を追加（token + user）
- `handler.go`: Signup/Loginのレスポンスを AuthResponse に変更

### Frontend
- `useAuth.ts`: AuthResponse型を追加、ログイン/サインアップ成功時にdocument.cookieでセット
- `Header.tsx`: ログアウト時にdocument.cookieでCookieを削除

## 注意事項
- document.cookieでセットするため、HttpOnlyにならない（XSSリスク）
- 本格的な対策として、Next.js API Routeプロキシ化を別Issueで対応予定
  → #XX 認証のNext.js API Routeプロキシ化（HttpOnly Cookie対応）

## テスト
- [ ] 本番環境でサインアップ → /dashboardに遷移する
- [ ] 本番環境でログイン → /dashboardに遷移する
- [ ] 本番環境でログアウト → /loginにリダイレクトされる
- [ ] ローカル環境でも従来通り動作する
