### PR TITLE
feat(frontend): 通知0件時の表示対応とモックデータの更新

### DIFF
--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -50,7 +50,7 @@ const NAV_ITEMS: NavItem[] = [
   },
 ]
 
-const MOCK_NOTIFICATION_COUNT = 3
+const MOCK_NOTIFICATION_COUNT = 0
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080'
@@ -114,18 +114,37 @@ export function Header() {
             {/* Right side UI area */}
             <div className="flex items-center gap-2 md:gap-4">
               {/* Notification Bell */}
-              <div className="relative inline-flex">
-                <button className="p-2 hover:bg-accent rounded-lg transition-colors flex items-center justify-center">
-                  <Bell className="w-5 h-5" />
-                </button>
-                {MOCK_NOTIFICATION_COUNT > 0 && (
-                  <span className="absolute -top-1 -right-1 min-w-5 h-5 bg-red-500 text-white text-xs rounded-full flex items-center justify-center leading-none font-bold">
-                    {MOCK_NOTIFICATION_COUNT > 9
-                      ? '9+'
-                      : MOCK_NOTIFICATION_COUNT}
-                  </span>
-                )}
-              </div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <div className="relative inline-flex">
+                    <button className="p-2 hover:bg-accent rounded-lg transition-colors flex items-center justify-center">
+                      <Bell className="w-5 h-5" />
+                    </button>
+                    {MOCK_NOTIFICATION_COUNT > 0 && (
+                      <span className="absolute -top-1 -right-1 min-w-5 h-5 bg-red-500 text-white text-xs rounded-full flex items-center justify-center leading-none font-bold">
+                        {MOCK_NOTIFICATION_COUNT > 9
+                          ? '9+'
+                          : MOCK_NOTIFICATION_COUNT}
+                      </span>
+                    )}
+                  </div>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuLabel>
+                    {MOCK_NOTIFICATION_COUNT === 0
+                      ? '通知がありません'
+                      : `未読通知が ${MOCK_NOTIFICATION_COUNT} 件あります`}
+                  </DropdownMenuLabel>
+                  {MOCK_NOTIFICATION_COUNT > 0 && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem>
+                        通知一覧を見る
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
 
               {/* Message Mail */}
               <div className="relative inline-flex">


### PR DESCRIPTION
#105 
# feat(frontend): 通知0件時のUI表示対応とモックデータの更新

# 概要
通知バッジの初期表示を0件（非表示）にし、通知がない場合にユーザーへその旨を伝えるUI（ドロップダウン）を実装しました。

# 変更内容
モックデータの更新:
frontend/src/components/layouts/Header.tsx 内の MOCK_NOTIFICATION_COUNT を 3 から 0 に変更しました。これにより、未読バッジがデフォルトで非表示になります。
通知UIの改善:
通知ベルアイコンを単なるボタンから DropdownMenu に変更しました。
通知が0件の場合に、アイコンをクリックすると「通知がありません」というメッセージが表示されるようにしました。
将来的に通知がある場合は、件数表示や「通知一覧を見る」リンクを表示できるよう拡張性を考慮した実装にしています。
# 動作確認内容
 ヘッダーの通知ベルに赤いバッジが表示されていないこと。
 通知ベルをクリックした際に、ドロップダウンで「通知がありません」と表示されること。