### PR TITLE
fix(ws,chat): クロスドメインWebSocket認証修正・セキュリティ改善・チャット表示バグ修正

### DIFF
--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -16,9 +16,13 @@ const (
 // AuthMiddleware はセッションベースの認証ミドルウェア
 func AuthMiddleware(service *Service) gin.HandlerFunc { // gin.HandlerFuncにGinがcを自動で渡す
 	return func(c *gin.Context) {
-		// 1. Cookieからセッショントークンを取得
+		// 1. Cookie → クエリパラメータの順でセッショントークンを取得
+		// クエリパラメータは WebSocket 接続など Cookie が送れないクロスドメイン環境向け
 		token, err := c.Cookie(SessionCookieName)
-		if err != nil {
+		if err != nil || token == "" {
+			token = c.Query("token")
+		}
+		if token == "" {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
 				"error": "認証が必要です",
 			})

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -16,10 +16,11 @@ const (
 // AuthMiddleware はセッションベースの認証ミドルウェア
 func AuthMiddleware(service *Service) gin.HandlerFunc { // gin.HandlerFuncにGinがcを自動で渡す
 	return func(c *gin.Context) {
-		// 1. Cookie → クエリパラメータの順でセッショントークンを取得
-		// クエリパラメータは WebSocket 接続など Cookie が送れないクロスドメイン環境向け
+		// 1. Cookie からセッショントークンを取得
+		// WebSocket アップグレードリクエストのみ、Cookie がない場合にクエリパラメータを許可
+		// （他のルートでクエリパラメータ経由のトークン漏洩リスクを避けるため限定）
 		token, err := c.Cookie(SessionCookieName)
-		if err != nil || token == "" {
+		if (err != nil || token == "") && c.GetHeader("Upgrade") == "websocket" {
 			token = c.Query("token")
 		}
 		if token == "" {

--- a/backend/internal/chat/websocket/handler.go
+++ b/backend/internal/chat/websocket/handler.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"log"
 	"net/http"
+	"os"
 
 	"backend/internal/auth"
 	"backend/internal/chat/message"
@@ -14,20 +15,31 @@ import (
 var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
 		origin := r.Header.Get("Origin")
-		return origin == "http://localhost:3000" || origin == ""
+		if origin == "" {
+			return true
+		}
+		corsOrigin := os.Getenv("CORS_ORIGIN")
+		if corsOrigin == "" {
+			corsOrigin = "http://localhost:3000"
+		}
+		return origin == corsOrigin
 	},
 }
 
 // ServeWs はWebSocket接続をアップグレードし、認証・ルーム取得後にクライアントを登録する
 func ServeWs(hub *Hub, authSvc *auth.Service, roomSvc *room.RoomService, msgSvc *message.MessageService, w http.ResponseWriter, r *http.Request) {
-	// session_token Cookie から認証
-	tokenCookie, err := r.Cookie(auth.SessionCookieName)
-	if err != nil {
-		http.Error(w, "認証が必要です", http.StatusUnauthorized)
-		return
+	// クエリパラメータ → Cookie の順でトークンを取得
+	token := r.URL.Query().Get("token")
+	if token == "" {
+		tokenCookie, err := r.Cookie(auth.SessionCookieName)
+		if err != nil {
+			http.Error(w, "認証が必要です", http.StatusUnauthorized)
+			return
+		}
+		token = tokenCookie.Value
 	}
 
-	user, err := authSvc.GetCurrentUser(r.Context(), tokenCookie.Value)
+	user, err := authSvc.GetCurrentUser(r.Context(), token)
 	if err != nil {
 		http.Error(w, "無効なセッションです", http.StatusUnauthorized)
 		return

--- a/frontend/src/app/(app)/chat/page.tsx
+++ b/frontend/src/app/(app)/chat/page.tsx
@@ -12,7 +12,7 @@ function ChatContent() {
   const searchParams = useSearchParams()
   const [selectedRoomId, setSelectedRoomId] = useState<string | undefined>(undefined)
 
-  const { chatRooms, wsURL, fetchMessages, addMessage, getMessages } = useChat()
+  const { chatRooms, currentUserId, wsURL, fetchMessages, addMessage, getMessages } = useChat()
 
   // ?room=<uuid> でルームを初期選択
   useEffect(() => {

--- a/frontend/src/app/(app)/chat/page.tsx
+++ b/frontend/src/app/(app)/chat/page.tsx
@@ -51,6 +51,7 @@ function ChatContent() {
               roomId={selectedRoomId}
               participantName={selectedRoom.participantName}
               messages={messages}
+              currentUserId={currentUserId}
               onReceiveMessage={addMessage}
               wsURL={wsURL}
             />

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -71,6 +71,7 @@ export function Header() {
       credentials: 'include',
     })
     document.cookie = 'session_token=; path=/; max-age=0'
+    sessionStorage.removeItem('session_token')
     router.push('/login')
   }
 

--- a/frontend/src/features/auth/hooks/useAuth.ts
+++ b/frontend/src/features/auth/hooks/useAuth.ts
@@ -13,6 +13,7 @@ type AuthResponse = {
 
 function setSessionCookie(token: string) {
   document.cookie = `session_token=${token}; path=/; max-age=86400`
+  sessionStorage.setItem('session_token', token)
 }
 
 export function useAuth() {

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -32,6 +32,11 @@ export function ChatWindow({
   const [inputValue, setInputValue] = useState('')
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const wsRef = useRef<WebSocket | null>(null)
+  const onReceiveMessageRef = useRef(onReceiveMessage)
+
+  useEffect(() => {
+    onReceiveMessageRef.current = onReceiveMessage
+  }, [onReceiveMessage])
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -42,7 +47,7 @@ export function ChatWindow({
     wsRef.current = ws
 
     ws.onopen = () => console.log('WebSocket opened')
-    ws.onmessage = (event) => onReceiveMessage(event.data)
+    ws.onmessage = (event) => onReceiveMessageRef.current(event.data)
     ws.onclose = () => console.log('WebSocket disconnected')
 
     return () => ws.close()

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -18,6 +18,7 @@ interface ChatWindowProps {
   roomId: string
   participantName: string
   messages: Message[]
+  currentUserId: string | null
   onReceiveMessage: (data: string) => void
   wsURL: string
 }
@@ -26,6 +27,7 @@ export function ChatWindow({
   roomId,
   participantName,
   messages,
+  currentUserId,
   onReceiveMessage,
   wsURL,
 }: ChatWindowProps) {
@@ -73,7 +75,7 @@ export function ChatWindow({
       </CardHeader>
       <CardContent className="flex-1 overflow-y-auto p-4 space-y-4">
         {messages.map((message) => {
-          const isOwn = message.senderId === 'current'
+          const isOwn = message.senderId === currentUserId
           return (
             <div
               key={message.id}

--- a/frontend/src/features/chat/hooks/useChat.ts
+++ b/frontend/src/features/chat/hooks/useChat.ts
@@ -6,6 +6,11 @@ import { Message, ChatRoom } from '../types/chat'
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080'
 const WS_BASE = API_BASE.replace(/^http/, 'ws')
 
+function getSessionToken(): string | null {
+  const match = document.cookie.match(/(^| )session_token=([^;]+)/)
+  return match ? match[2] : null
+}
+
 export function useChat(initialRoomId?: string) {
   const [chatRooms, setChatRooms] = useState<ChatRoom[]>([])
   const [messages, setMessages] = useState<Record<string, Message[]>>({})
@@ -105,7 +110,8 @@ export function useChat(initialRoomId?: string) {
     [messages],
   )
 
-  const wsURL = `${WS_BASE}/ws`
+  const token = getSessionToken()
+  const wsURL = `${WS_BASE}/ws${token ? `?token=${token}` : ''}`
 
   return {
     chatRooms,

--- a/frontend/src/features/chat/hooks/useChat.ts
+++ b/frontend/src/features/chat/hooks/useChat.ts
@@ -7,8 +7,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080'
 const WS_BASE = API_BASE.replace(/^http/, 'ws')
 
 function getSessionToken(): string | null {
-  const match = document.cookie.match(/(^| )session_token=([^;]+)/)
-  return match ? match[2] : null
+  return sessionStorage.getItem('session_token')
 }
 
 export function useChat(initialRoomId?: string) {
@@ -63,14 +62,14 @@ export function useChat(initialRoomId?: string) {
       [roomId]: data.map((m) => ({
         id: String(m.id),
         roomId: m.room_id,
-        senderId: m.sender_id,
-        senderName: m.sender_name,
+        senderId: m.sender_id === currentUserId ? 'current' : m.sender_id,
+        senderName: m.sender_id === currentUserId ? 'あなた' : m.sender_name,
         content: m.content,
         timestamp: new Date(m.created_at),
         isRead: true,
       })),
     }))
-  }, [])
+  }, [currentUserId])
 
   // WebSocket からのメッセージを受信して state に反映
   const addMessage = useCallback(

--- a/frontend/src/features/chat/hooks/useChat.ts
+++ b/frontend/src/features/chat/hooks/useChat.ts
@@ -7,6 +7,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080'
 const WS_BASE = API_BASE.replace(/^http/, 'ws')
 
 function getSessionToken(): string | null {
+  if (typeof window === 'undefined') return null
   return sessionStorage.getItem('session_token')
 }
 
@@ -62,14 +63,14 @@ export function useChat(initialRoomId?: string) {
       [roomId]: data.map((m) => ({
         id: String(m.id),
         roomId: m.room_id,
-        senderId: m.sender_id === currentUserId ? 'current' : m.sender_id,
-        senderName: m.sender_id === currentUserId ? 'あなた' : m.sender_name,
+        senderId: m.sender_id,
+        senderName: m.sender_name,
         content: m.content,
         timestamp: new Date(m.created_at),
         isRead: true,
       })),
     }))
-  }, [currentUserId])
+  }, [])
 
   // WebSocket からのメッセージを受信して state に反映
   const addMessage = useCallback(
@@ -87,8 +88,8 @@ export function useChat(initialRoomId?: string) {
         const newMessage: Message = {
           id: String(msg.id),
           roomId: msg.room_id,
-          senderId: msg.sender_id === currentUserId ? 'current' : msg.sender_id,
-          senderName: msg.sender_id === currentUserId ? 'あなた' : msg.sender_name,
+          senderId: msg.sender_id,
+          senderName: msg.sender_name,
           content: msg.content,
           timestamp: new Date(msg.created_at),
           isRead: false,
@@ -101,7 +102,7 @@ export function useChat(initialRoomId?: string) {
         // parse error は無視
       }
     },
-    [currentUserId],
+    [],
   )
 
   const getMessages = useCallback(


### PR DESCRIPTION

<h2><code>fix(ws,chat): クロスドメインWebSocket認証修正・セキュリティ改善・チャット表示バグ修正</code></h2>
<h2>概要</h2>
<p>本番環境（Vercel + Railway）での WebSocket 認証失敗、PRレビュー指摘への対応、およびチャットメッセージの表示バグを修正。</p>
<h2>原因と対応</h2>
<h3>1. WebSocket 認証失敗（#107）</h3>
<p><strong>原因：</strong> WebSocket API には HTTP fetch の <code>credentials: 'include'</code> に相当するオプションがなく、クロスドメイン環境では Cookie が自動送信されない。バックエンド側が Cookie からしかトークンを取得していなかったため、本番では常に 401 になっていた。</p>
<p><strong>対応：</strong></p>
<ul>
<li><code>AuthMiddleware</code> にクエリパラメータ <code>?token=</code> のフォールバックを追加</li>
<li><code>ServeWs</code> でも同様にクエリパラメータ → Cookie の順でトークンを取得</li>
<li><code>upgrader.CheckOrigin</code> を <code>CORS_ORIGIN</code> 環境変数で判定するように変更（<code>localhost</code> ハードコード廃止）</li>
<li>フロント側で <code>document.cookie</code> からトークンを読み取り WebSocket URL に <code>?token=</code> として付与</li>
</ul>
<h3>2. PRレビュー指摘への対応</h3>

レビュー | 対応
-- | --
ルートでクエリパラメータによるトークン取得を許可するのはセキュリティリスク（サーバーログ・Referer 経由の漏洩） | AuthMiddleware の ?token= 許可を Upgrade: websocket ヘッダーがある場合のみに限定
document.cookie は HttpOnly Cookie を読めない、XSS リスクが高まる | ログイン時に sessionStorage にもトークンを保存し、WebSocket はそこから読み取るよう変更。ログアウト時も sessionStorage をクリア


<h3>3. チャットメッセージ表示バグ</h3>
<p><strong>症状：</strong> チャット後しばらく経つと自分が送ったメッセージが相手側のメッセージとして表示される。</p>
<p><strong>原因（2つ）：</strong></p>
<ol>
<li><strong><code>fetchMessages</code> が <code>'current'</code> を設定しない</strong> — WebSocket 経由のリアルタイムメッセージは <code>senderId: 'current'</code> でマークされるが、履歴取得では生の <code>sender_id</code> をそのまま使っていた。ルーム切り替え時に履歴が上書きされ、自分のメッセージが相手側に見える</li>
<li><strong><code>ws.onmessage</code> のスタールクロージャ</strong> — WebSocket は <code>[wsURL]</code> 依存で生成されるため、その後 <code>currentUserId</code> が非同期で変わっても <code>onmessage</code> は古い <code>addMessage</code>（<code>currentUserId = null</code>）を呼び続ける</li>
</ol>
<p><strong>修正：</strong></p>
<ul>
<li><code>fetchMessages</code> で <code>sender_id === currentUserId</code> を判定し、<code>senderId: 'current'</code> / <code>senderName: 'あなた'</code> をセット。依存配列に <code>currentUserId</code> を追加</li>
<li><code>ChatWindow</code> に <code>onReceiveMessageRef</code> を導入し、<code>onmessage</code> が常に最新の <code>addMessage</code> を使うように修正</li>
</ul>
<h2>コミット構成</h2>

PRに以下を追加：

---

### 4. レビュー指摘対応 + SSR エラー修正

**追加コミット：**

- **`fix(chat): メッセージの送信者判定をレンダリング時に行うよう変更`**
    - state には生の `sender_id` を保持し、`ChatWindow` で `currentUserId` と比較することでレースコンディションによる表示バグを修正（@gemini-code-assist 指摘）
    - `getSessionToken()` に SSR ガード（`typeof window === 'undefined'`）を追加し、チャット画面リロード時の `sessionStorage is not defined` エラーを修正
    - `chat/page.tsx` で `currentUserId` の destructure 漏れを修正（ビルドエラー対応）

**変更ファイル：**

- `frontend/src/features/chat/hooks/useChat.ts`
- `frontend/src/features/chat/components/ChatWindow.tsx`
- `frontend/src/app/(app)/chat/page.tsx`

<ol>
<li><strong><code>fix(ws): クロスドメイン環境でのWebSocket認証失敗を修正</code></strong>
<ul>
<li><code>backend/internal/auth/middleware.go</code></li>
<li><code>backend/internal/chat/websocket/handler.go</code></li>
<li><code>frontend/src/features/chat/hooks/useChat.ts</code></li>
</ul>
</li>
<li><strong><code>fix(auth): WebSocket認証のセキュリティ改善とsessionStorage対応</code></strong>
<ul>
<li><code>backend/internal/auth/middleware.go</code></li>
<li><code>frontend/src/features/auth/hooks/useAuth.ts</code></li>
<li><code>frontend/src/components/layouts/Header.tsx</code></li>
</ul>
</li>
<li><strong><code>fix(chat): 自分のメッセージが相手側に表示されるバグを修正</code></strong>
<ul>
<li><code>frontend/src/features/chat/hooks/useChat.ts</code></li>
<li><code>frontend/src/features/chat/components/ChatWindow.tsx</code></li>
</ul>
</li>
</ol>
<h2>テスト観点</h2>
<ul>
<li>[ ]  本番（Vercel + Railway）で WebSocket 接続が成功し、チャットが動作する</li>
<li>[ ]  チャットルーム切り替え後も自分のメッセージが正しく右側（自分側）に表示される</li>
<li>[ ]  通常の API リクエスト（非 WebSocket）でクエリパラメータによるトークン取得が無効であること</li>
<li>[ ]  ローカル（Docker）で Cookie ベースの既存動作が壊れていない</li>
<li>[ ]  未ログイン状態で WebSocket 接続が 401 で正しく拒否される</li>
<li>[ ]  <code>CheckOrigin</code> が <code>CORS_ORIGIN</code> 環境変数に基づいて正しく判定される</li>
<li>[ ]  ログイン → チャット → ログアウト → 再ログインの一連フローが正常に動作する</li>
<li>[ ]  チャット画面をリロードしても SSR エラーが発生しないこと</li>
<li>[ ]  `/api/auth/me` の解決前にルームを選択しても、自分のメッセージが正しく右側に表示されること</li>
</ul>
<h2>関連 Issue</h2>
<ul>
<li>Closes #107</li>
</ul>
<!-- notionvc: 0b6daa47-a746-452e-8a36-eb02ed7e90c9 --></body></html>