### PR TITLE
feat: ユーザープロフィールの確認・変更機能の実装

### DIFF
--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -82,7 +82,6 @@ func (h *Handler) Logout(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "ログアウトしました"})
 }
 
-// Me GET /api/auth/me
 func (h *Handler) Me(c *gin.Context) {
 	user, ok := GetCurrentUserFromContext(c)
 	if !ok {
@@ -90,6 +89,37 @@ func (h *Handler) Me(c *gin.Context) {
 		return
 	}
 
+	c.JSON(http.StatusOK, user)
+}
+
+// UpdateMe PUT /api/auth/me
+func (h *Handler) UpdateMe(c *gin.Context) {
+	// 1. Contextから現在ログイン中のユーザー情報を取得
+	currentUser, ok := GetCurrentUserFromContext(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "認証が必要です"})
+		return
+	}
+
+	// 2. リクエストボディをパース
+	var req UpdateMeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "リクエストが不正です"})
+		return
+	}
+
+	// 3. サービス層を呼ぶ
+	user, err := h.service.UpdateMe(c.Request.Context(), currentUser.ID, req)
+	if err != nil {
+		if err == ErrEmailAlreadyExists {
+			c.JSON(http.StatusConflict, gin.H{"error": "このメールアドレスは既に使用されています"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "サーバーエラーが発生しました"})
+		return
+	}
+
+	// 4. 更新後のユーザー情報を返す
 	c.JSON(http.StatusOK, user)
 }
 

--- a/backend/internal/auth/model.go
+++ b/backend/internal/auth/model.go
@@ -43,6 +43,12 @@ type LoginRequest struct {
 	Password string `json:"password" binding:"required"`
 }
 
+// UpdateMeRequest はユーザー情報の更新時にクライアントから受け取るJSON
+type UpdateMeRequest struct {
+	Email       string `json:"email" binding:"required,email"`
+	DisplayName string `json:"display_name" binding:"required"`
+}
+
 // APIレスポンス用の構造体
 
 // UserResponseはクライアントに返すユーザー情報

--- a/backend/internal/auth/repository.go
+++ b/backend/internal/auth/repository.go
@@ -12,6 +12,7 @@ type Repository interface {
 	CreateUser(ctx context.Context, user *User) error
 	GetUserByEmail(ctx context.Context, email string) (*User, error)
 	GetUserByID(ctx context.Context, id uuid.UUID) (*User, error)
+	UpdateUser(ctx context.Context, user *User) error
 
 	// セッション操作
 	CreateSession(ctx context.Context, session *Session) error

--- a/backend/internal/auth/repository_postgres.go
+++ b/backend/internal/auth/repository_postgres.go
@@ -74,6 +74,30 @@ func (r *PostgresRepository) GetUserByID(ctx context.Context, id uuid.UUID) (*Us
 	return &user, nil
 }
 
+func (r *PostgresRepository) UpdateUser(ctx context.Context, user *User) error {
+	query := `
+		UPDATE users
+		SET email = :email, display_name = :display_name, updated_at = NOW()
+		WHERE id = :id
+	`
+	result, err := r.db.NamedExecContext(ctx, query, user)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return ErrDuplicateEmail
+		}
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return ErrUserNotFound
+	}
+	return nil
+}
+
 func (r *PostgresRepository) CreateSession(ctx context.Context, session *Session) error {
 	query := `
 		INSERT INTO sessions (id, user_id, token, expires_at)

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -103,7 +103,7 @@ func (s *Service) Login(ctx context.Context, req LoginRequest) (*UserResponse, s
 	// 4. レスポンスを返す
 	return toUserResponse(user), token, nil
 }
-
+	// ログアウト
 func (s *Service) Logout(ctx context.Context, token string) error {
 	return s.repo.DeleteSessionByToken(ctx, token)
 }

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -104,10 +104,43 @@ func (s *Service) Login(ctx context.Context, req LoginRequest) (*UserResponse, s
 	return toUserResponse(user), token, nil
 }
 
-// ログアウト
-
 func (s *Service) Logout(ctx context.Context, token string) error {
 	return s.repo.DeleteSessionByToken(ctx, token)
+}
+
+// ユーザー情報更新
+
+func (s *Service) UpdateMe(ctx context.Context, userID uuid.UUID, req UpdateMeRequest) (*UserResponse, error) {
+	// 1. ユーザーを取得
+	user, err := s.repo.GetUserByID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. メールアドレスが変更される場合、重複チェック
+	if req.Email != user.Email {
+		_, err := s.repo.GetUserByEmail(ctx, req.Email)
+		if err == nil {
+			return nil, ErrEmailAlreadyExists
+		}
+		if !errors.Is(err, ErrUserNotFound) {
+			return nil, err
+		}
+	}
+
+	// 3. フィールドを更新
+	user.Email = req.Email
+	user.DisplayName = req.DisplayName
+
+	// 4. DB保存
+	if err := s.repo.UpdateUser(ctx, user); err != nil {
+		if errors.Is(err, ErrDuplicateEmail) {
+			return nil, ErrEmailAlreadyExists
+		}
+		return nil, err
+	}
+
+	return toUserResponse(user), nil
 }
 
 // 現在のユーザー情報

--- a/backend/main.go
+++ b/backend/main.go
@@ -90,6 +90,7 @@ func main() {
 	{
 		protected.POST("/auth/logout", authHandler.Logout)
 		protected.GET("/auth/me", authHandler.Me)
+		protected.PUT("/auth/me", authHandler.UpdateMe)
 
 		// チャット
 		protected.GET("/rooms", chatHandler.GetRooms)

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -1,0 +1,13 @@
+import { SettingsMain } from '@/features/settings'
+
+export const metadata = {
+  title: '設定 - ActBuddy',
+}
+
+export default function SettingsPage() {
+  return (
+    <main>
+      <SettingsMain />
+    </main>
+  )
+}

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -59,7 +59,7 @@ export function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const [mounted, setMounted] = useState(false)
   const router = useRouter()
-  const currentUser = useCurrentUser()
+  const { user: currentUser } = useCurrentUser()
 
   useEffect(() => {
     setMounted(true)
@@ -147,13 +147,11 @@ export function Header() {
                 <DropdownMenuContent align="end">
                   <DropdownMenuLabel>{mounted ? (currentUser?.display_name ?? '') : ''}</DropdownMenuLabel>
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem>
-                    <UserCircle className="w-4 h-4 mr-2" />
-                    プロフィール
-                  </DropdownMenuItem>
-                  <DropdownMenuItem>
-                    <Settings className="w-4 h-4 mr-2" />
-                    設定
+                  <DropdownMenuItem asChild>
+                    <Link href="/settings" className="w-full flex items-center">
+                      <Settings className="w-4 h-4 mr-2" />
+                      設定
+                    </Link>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem

--- a/frontend/src/features/auth/hooks/useCurrentUser.ts
+++ b/frontend/src/features/auth/hooks/useCurrentUser.ts
@@ -9,14 +9,18 @@ const API_BASE_URL =
 export function useCurrentUser() {
   const [user, setUser] = useState<UserResponse | null>(null)
 
-  useEffect(() => {
+  const refresh = () => {
     fetch(`${API_BASE_URL}/api/auth/me`, {
       credentials: 'include',
     })
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => setUser(data))
       .catch(() => setUser(null))
+  }
+
+  useEffect(() => {
+    refresh()
   }, [])
 
-  return user
+  return { user, refresh }
 }

--- a/frontend/src/features/calendar/hooks/useCalendar.ts
+++ b/frontend/src/features/calendar/hooks/useCalendar.ts
@@ -52,7 +52,7 @@ async function fetchActionItemsForUser(
 }
 
 export function useCalendar() {
-  const currentUser = useCurrentUser()
+  const { user: currentUser } = useCurrentUser()
   const [view, setView] = useState<CalendarView>('month')
   const [selectedDate, setSelectedDate] = useState<Date>(new Date())
   const [ownItems, setOwnItems] = useState<ActionItem[]>([])

--- a/frontend/src/features/home/components/HomeMain.tsx
+++ b/frontend/src/features/home/components/HomeMain.tsx
@@ -33,7 +33,7 @@ interface TodayStats {
 }
 
 export default function HomeMain() {
-  const currentUser = useCurrentUser()
+  const { user: currentUser } = useCurrentUser()
   const [capacity, setCapacity] = useState<CapacityData | null>(null)
   const [profile, setProfile] = useState<ProfileData | null>(null)
   const [todayStats, setTodayStats] = useState<TodayStats | null>(null)

--- a/frontend/src/features/settings/components/SettingsMain.tsx
+++ b/frontend/src/features/settings/components/SettingsMain.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useCurrentUser } from '@/features/auth/hooks/useCurrentUser'
+import { Settings, User, Mail, Save, Loader2 } from 'lucide-react'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080'
+
+export default function SettingsMain() {
+  const { user: currentUser, refresh } = useCurrentUser()
+  const [displayName, setDisplayName] = useState('')
+  const [email, setEmail] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [message, setMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null)
+
+  useEffect(() => {
+    if (currentUser) {
+      setDisplayName(currentUser.display_name)
+      setEmail(currentUser.email)
+    }
+  }, [currentUser])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsLoading(true)
+    setMessage(null)
+
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/me`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          display_name: displayName,
+          email: email,
+        }),
+        credentials: 'include',
+      })
+
+      if (res.ok) {
+        setMessage({ type: 'success', text: '設定を更新しました。' })
+        refresh()
+      } else {
+        const data = await res.json()
+        setMessage({ type: 'error', text: data.error || '更新に失敗しました。' })
+      }
+    } catch (err) {
+      setMessage({ type: 'error', text: '通信エラーが発生しました。' })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  if (!currentUser) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="max-w-2xl mx-auto">
+        <div className="flex items-center gap-2 mb-8">
+          <Settings className="w-8 h-8 text-primary" />
+          <h1 className="text-3xl font-bold">設定</h1>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <Card>
+            <CardHeader>
+              <CardTitle>アカウント情報</CardTitle>
+              <CardDescription>
+                表示名やメールアドレスを変更できます。
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {message && (
+                <div
+                  className={`p-4 rounded-md text-sm ${
+                    message.type === 'success'
+                      ? 'bg-green-500/10 text-green-600'
+                      : 'bg-red-500/10 text-red-600'
+                  }`}
+                >
+                  {message.text}
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="display_name" className="flex items-center gap-2">
+                  <User className="w-4 h-4" />
+                  表示名
+                </Label>
+                <Input
+                  id="display_name"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  placeholder="ユーザー名を入力してください"
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="email" className="flex items-center gap-2">
+                  <Mail className="w-4 h-4" />
+                  メールアドレス
+                </Label>
+                <Input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="example@email.com"
+                  required
+                />
+              </div>
+            </CardContent>
+            <CardFooter className="flex justify-end border-t pt-6">
+              <Button type="submit" disabled={isLoading} className="gap-2">
+                {isLoading ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Save className="w-4 h-4" />
+                )}
+                変更を保存
+              </Button>
+            </CardFooter>
+          </Card>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/settings/index.ts
+++ b/frontend/src/features/settings/index.ts
@@ -1,0 +1,2 @@
+// Settings Featureのエントリーポイント
+export { default as SettingsMain } from './components/SettingsMain'


### PR DESCRIPTION
# ユーザー設定（プロフィール更新）機能の実装
# 概要
ユーザーが自分の表示名とメールアドレスを確認・変更できる設定画面を実装しました。また、ユーザーメニューから不要な「プロフィール」項目を削除し、「設定」画面に統合することでUIを整理しました。

# 実施内容
## フロントエンド
設定画面の新規作成: (app)/settings/page.tsx を追加。表示名とメールアドレスの変更フォームを実装しました。
ヘッダーメニューの調整:
メニューから「プロフィール」項目を削除。
「設定」項目を /settings へのリンクに修正。
状態管理の改善: プロフィール更新後に、ヘッダー等の全パーツでユーザー名が即座に同期されるよう、useCurrentUser ホックに refresh 機能を追加しました。
## バックエンド（レイヤー構造に準拠）
Handler: UpdateMe ハンドラーを追加し、リクエストのパースとバリデーションを実装。
Service: 変更されたメールアドレスの重複チェックを含むビジネスロジックを実装。
Repository: DBに対してユーザー情報を更新する UpdateUser インターフェースとその実装（Postgres）を追加。
Routing: PUT /api/auth/me を保護されたAPIルートとして登録。
# 認証・アクセス制限
既存の認証ミドルウェアに基づき、ログインしていない場合は /settings ページにアクセスできないよう設定済みです（(app) ルートグループ内に配置）。
# 動作確認方法
ログイン後、ヘッダー右上のアイコンをクリック。
「設定」を選択し、設定画面へ遷移。
表示名やメールアドレスを入力し、「変更を保存」をクリック。
成功メッセージが表示され、画面右上の表示名（イニシャル）やダッシュボードの挨拶が即座に反映されることを確認。
ログアウトした状態で /settings に直接アクセスし、ログイン画面へリダイレクトされることを確認。
# 関連 Issue
Fixes #106 