### PR TITLE
feat(dashboard): ダッシュボード画面をブラッシュアップ

### DIFF
--- a/frontend/src/features/home/components/BuddyWidget.tsx
+++ b/frontend/src/features/home/components/BuddyWidget.tsx
@@ -1,0 +1,103 @@
+import Link from 'next/link'
+import { Users, MessageCircle, Share2, UserPlus } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import type { Buddy } from '@/features/buddies/types/buddy'
+
+interface BuddyWidgetProps {
+  buddies: Buddy[]
+  loading: boolean
+}
+
+interface BuddyRowProps {
+  buddy: Buddy
+}
+
+function BuddyRow({ buddy }: BuddyRowProps) {
+  return (
+    <li className="flex items-center gap-3 py-3 border-b last:border-b-0">
+      {/* アバター */}
+      <div className="w-9 h-9 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+        <span className="text-sm font-semibold text-primary">
+          {buddy.partnerName.charAt(0)}
+        </span>
+      </div>
+
+      {/* 名前 */}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium truncate">{buddy.partnerName}</p>
+        <p className="text-xs text-muted-foreground">バディ</p>
+      </div>
+
+      {/* 行動ボタン */}
+      <div className="flex items-center gap-2 shrink-0">
+        <Button
+          variant="outline"
+          size="sm"
+          className="text-xs gap-1"
+          asChild
+        >
+          <Link href={buddy.roomId ? `/chat?roomId=${buddy.roomId}` : '/chat'}>
+            <Share2 className="w-3 h-3" />
+            進捗を共有
+          </Link>
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-xs gap-1"
+          asChild
+        >
+          <Link href={buddy.roomId ? `/chat?roomId=${buddy.roomId}` : '/chat'}>
+            <MessageCircle className="w-3 h-3" />
+            チャット
+          </Link>
+        </Button>
+      </div>
+    </li>
+  )
+}
+
+export default function BuddyWidget({ buddies, loading }: BuddyWidgetProps) {
+  const activeBuddies = buddies.filter((b) => b.status === 'active')
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center gap-2">
+          <Users className="w-5 h-5 text-blue-500" />
+          <CardTitle className="text-base">バディ</CardTitle>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        {loading ? (
+          <div className="space-y-3 py-2">
+            {[...Array(2)].map((_, i) => (
+              <div key={i} className="h-12 rounded-md bg-muted animate-pulse" />
+            ))}
+          </div>
+        ) : activeBuddies.length === 0 ? (
+          // Empty state: CTAを第一要素に
+          <div className="py-4 text-center">
+            <p className="text-sm text-muted-foreground mb-4">
+              バディと一緒に目標を達成しましょう
+            </p>
+            <Button asChild variant="outline">
+              <Link href="/matching" className="gap-2">
+                <UserPlus className="w-4 h-4" />
+                バディを招待する
+              </Link>
+            </Button>
+          </div>
+        ) : (
+          <ul>
+            {activeBuddies.map((buddy) => (
+              <BuddyRow key={buddy.id} buddy={buddy} />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/features/home/components/DashboardGreeting.tsx
+++ b/frontend/src/features/home/components/DashboardGreeting.tsx
@@ -1,0 +1,46 @@
+import type { TodayStats } from '../types'
+
+interface DashboardGreetingProps {
+  displayName: string
+  todayStats: TodayStats
+}
+
+function getGreeting(): string {
+  const hour = new Date().getHours()
+  if (hour >= 5 && hour < 12) return 'おはようございます'
+  if (hour >= 12 && hour < 18) return 'こんにちは'
+  return 'こんばんは'
+}
+
+function formatDate(date: Date): string {
+  const DAYS = ['日', '月', '火', '水', '木', '金', '土']
+  const m = date.getMonth() + 1
+  const d = date.getDate()
+  const dow = DAYS[date.getDay()]
+  return `${m}月${d}日（${dow}）`
+}
+
+function buildStatusSummary(stats: TodayStats): string {
+  if (stats.total === 0) return '今日のタスクはまだありません'
+  if (stats.completed === stats.total) return `今日のタスク${stats.total}件、すべて完了`
+  return `今日: タスク${stats.total}件 · ${stats.completed}件完了`
+}
+
+export default function DashboardGreeting({
+  displayName,
+  todayStats,
+}: DashboardGreetingProps) {
+  const today = new Date()
+
+  return (
+    <div>
+      <div className="flex items-baseline gap-3 flex-wrap">
+        <h1 className="text-3xl font-bold">
+          {displayName ? `${getGreeting()}、${displayName}さん` : 'ダッシュボード'}
+        </h1>
+        <span className="text-sm text-muted-foreground">{formatDate(today)}</span>
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground">{buildStatusSummary(todayStats)}</p>
+    </div>
+  )
+}

--- a/frontend/src/features/home/components/GoalBadges.tsx
+++ b/frontend/src/features/home/components/GoalBadges.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link'
+import { Target, ArrowRight } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+interface GoalBadgesProps {
+  goalTypes: string[]
+  bio?: string
+}
+
+export default function GoalBadges({ goalTypes, bio }: GoalBadgesProps) {
+  if (goalTypes.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Target className="w-5 h-5 text-primary" />
+            <CardTitle className="text-base">設定中の目標</CardTitle>
+          </div>
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/matching" className="flex items-center gap-1 text-xs">
+              プロフィールを編集
+              <ArrowRight className="w-3 h-3" />
+            </Link>
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-wrap gap-2">
+          {goalTypes.map((goal) => (
+            <span
+              key={goal}
+              className="px-3 py-1 bg-primary/10 text-primary text-sm rounded-full"
+            >
+              {goal}
+            </span>
+          ))}
+        </div>
+        {bio && <p className="mt-3 text-sm text-muted-foreground">{bio}</p>}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/features/home/components/HomeMain.tsx
+++ b/frontend/src/features/home/components/HomeMain.tsx
@@ -1,229 +1,45 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { Users, Calendar, Target, TrendingUp, ArrowRight } from 'lucide-react'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Progress } from '@/components/ui/progress'
-import Link from 'next/link'
 import { useCurrentUser } from '@/features/auth/hooks/useCurrentUser'
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080'
-
-interface CapacityData {
-  current_count: number
-  max_count: number
-  achievement_rate: number
-}
-
-interface ProfileData {
-  goal_types: string[]
-  bio: string
-}
-
-interface TodayStats {
-  total: number
-  completed: number
-}
+import { useBuddies } from '@/features/buddies/hooks/useBuddies'
+import { useDashboard } from '../hooks/useDashboard'
+import DashboardGreeting from './DashboardGreeting'
+import StatsSection from './StatsSection'
+import TodayTasksWidget from './TodayTasksWidget'
+import GoalBadges from './GoalBadges'
+import BuddyWidget from './BuddyWidget'
+import QuickActions from './QuickActions'
 
 export default function HomeMain() {
   const { user: currentUser } = useCurrentUser()
-  const [capacity, setCapacity] = useState<CapacityData | null>(null)
-  const [profile, setProfile] = useState<ProfileData | null>(null)
-  const [todayStats, setTodayStats] = useState<TodayStats | null>(null)
-  const [mounted, setMounted] = useState(false)
+  const { capacity, profile, big3, todayStats, loading, updateTaskStatus } = useDashboard()
+  const { buddies, loading: buddiesLoading } = useBuddies()
 
-  useEffect(() => {
-    setMounted(true)
-
-    fetch(`${API_BASE}/api/buddy/capacity`, { credentials: 'include' })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d) => d && setCapacity(d))
-      .catch(() => null)
-
-    fetch(`${API_BASE}/api/buddy/profile`, { credentials: 'include' })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d) => d && setProfile(d))
-      .catch(() => null)
-
-    fetch(`${API_BASE}/api/v1/action-items`, { credentials: 'include' })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((body: { data: Array<{ status: string; kind: string; start_time: string }> } | null) => {
-        if (!body?.data) return
-        const todayStart = new Date()
-        todayStart.setHours(0, 0, 0, 0)
-        const todayEnd = new Date()
-        todayEnd.setHours(23, 59, 59, 999)
-        const tasks = body.data.filter((i) => {
-          if (i.kind === 'break') return false
-          const t = new Date(i.start_time)
-          return t >= todayStart && t <= todayEnd
-        })
-        const done = tasks.filter(
-          (i) => i.status === 'completed' || i.status === 'progress_70'
-        ).length
-        setTodayStats({ total: tasks.length, completed: done })
-      })
-      .catch(() => null)
-  }, [])
-
-  const achievementRate = capacity
-    ? Math.round(capacity.achievement_rate * 100)
-    : null
-
-  const displayName = mounted ? (currentUser?.display_name ?? '') : ''
+  // useCurrentUser は useEffect で非同期フェッチするため、
+  // サーバー・クライアント双方の初期値が null で一致しており hydration mismatch は発生しない
+  const displayName = currentUser?.display_name ?? ''
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <div className="max-w-4xl mx-auto">
-        {/* グリーティング */}
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold mb-1">
-            {displayName ? `こんにちは、${displayName}さん` : 'ダッシュボード'}
-          </h1>
-          <p className="text-muted-foreground">今日も一緒に目標に向かって進みましょう</p>
-        </div>
+      <div className="max-w-4xl mx-auto space-y-8">
+        <DashboardGreeting displayName={displayName} todayStats={todayStats} />
 
-        {/* ステータスカード */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-          {/* 達成率 */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-3 mb-3">
-                <div className="p-2 bg-primary/10 rounded-lg">
-                  <TrendingUp className="w-5 h-5 text-primary" />
-                </div>
-                <p className="text-sm text-muted-foreground">直近7日の達成率</p>
-              </div>
-              <p className="text-3xl font-bold mb-2">
-                {achievementRate !== null ? `${achievementRate}%` : '—'}
-              </p>
-              {achievementRate !== null && (
-                <Progress value={achievementRate} className="h-2" />
-              )}
-            </CardContent>
-          </Card>
+        <StatsSection capacity={capacity} todayStats={todayStats} loading={loading} />
 
-          {/* バディ枠 */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-3 mb-3">
-                <div className="p-2 bg-blue-500/10 rounded-lg">
-                  <Users className="w-5 h-5 text-blue-500" />
-                </div>
-                <p className="text-sm text-muted-foreground">バディ</p>
-              </div>
-              <p className="text-3xl font-bold mb-1">
-                {capacity !== null
-                  ? `${capacity.current_count} / ${capacity.max_count}`
-                  : '—'}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {capacity !== null ? `上限 ${capacity.max_count}人` : '読み込み中...'}
-              </p>
-            </CardContent>
-          </Card>
+        <TodayTasksWidget
+          tasks={big3}
+          totalCount={todayStats.total}
+          loading={loading}
+          onUpdateStatus={updateTaskStatus}
+        />
 
-          {/* 今日のAction Item */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-3 mb-3">
-                <div className="p-2 bg-green-500/10 rounded-lg">
-                  <Calendar className="w-5 h-5 text-green-500" />
-                </div>
-                <p className="text-sm text-muted-foreground">今日のタスク</p>
-              </div>
-              <p className="text-3xl font-bold mb-1">
-                {todayStats !== null
-                  ? `${todayStats.completed} / ${todayStats.total}`
-                  : '—'}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {todayStats !== null
-                  ? `${todayStats.total}件中${todayStats.completed}件完了`
-                  : '読み込み中...'}
-              </p>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* 目標 */}
-        {profile && profile.goal_types.length > 0 && (
-          <Card className="mb-8">
-            <CardHeader className="pb-3">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Target className="w-5 h-5 text-primary" />
-                  <CardTitle className="text-base">設定中の目標</CardTitle>
-                </div>
-                <Button variant="ghost" size="sm" asChild>
-                  <Link href="/matching" className="flex items-center gap-1 text-xs">
-                    プロフィールを編集
-                    <ArrowRight className="w-3 h-3" />
-                  </Link>
-                </Button>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="flex flex-wrap gap-2">
-                {profile.goal_types.map((goal) => (
-                  <span
-                    key={goal}
-                    className="px-3 py-1 bg-primary/10 text-primary text-sm rounded-full"
-                  >
-                    {goal}
-                  </span>
-                ))}
-              </div>
-              {profile.bio && (
-                <p className="mt-3 text-sm text-muted-foreground">{profile.bio}</p>
-              )}
-            </CardContent>
-          </Card>
+        {profile && profile.goalTypes.length > 0 && (
+          <GoalBadges goalTypes={profile.goalTypes} bio={profile.bio} />
         )}
 
-        {/* クイックアクション */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <Card className="hover:shadow-md transition-shadow cursor-pointer">
-            <Link href="/matching">
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <Users className="w-8 h-8 text-primary" />
-                    <div>
-                      <CardTitle className="text-base">バディを探す</CardTitle>
-                      <CardDescription>目標が近い人とマッチング</CardDescription>
-                    </div>
-                  </div>
-                  <ArrowRight className="w-4 h-4 text-muted-foreground" />
-                </div>
-              </CardHeader>
-            </Link>
-          </Card>
+        <BuddyWidget buddies={buddies} loading={buddiesLoading} />
 
-          <Card className="hover:shadow-md transition-shadow cursor-pointer">
-            <Link href="/calendar">
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <Calendar className="w-8 h-8 text-primary" />
-                    <div>
-                      <CardTitle className="text-base">カレンダー</CardTitle>
-                      <CardDescription>Action Itemを管理する</CardDescription>
-                    </div>
-                  </div>
-                  <ArrowRight className="w-4 h-4 text-muted-foreground" />
-                </div>
-              </CardHeader>
-            </Link>
-          </Card>
-        </div>
+        <QuickActions />
       </div>
     </div>
   )

--- a/frontend/src/features/home/components/QuickActions.tsx
+++ b/frontend/src/features/home/components/QuickActions.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link'
+import { Users, CalendarPlus, MessageCircle, ArrowRight } from 'lucide-react'
+import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+
+interface QuickActionItem {
+  href: string
+  icon: React.ReactNode
+  title: string
+  description: string
+}
+
+const ACTIONS: QuickActionItem[] = [
+  {
+    href: '/matching',
+    icon: <Users className="w-8 h-8 text-primary" />,
+    title: 'バディを探す',
+    description: '目標が近い人とマッチング',
+  },
+  {
+    href: '/calendar',
+    icon: <CalendarPlus className="w-8 h-8 text-green-500" />,
+    title: '今日のタスクを追加',
+    description: 'カレンダーでAction Itemを管理',
+  },
+  {
+    href: '/chat',
+    icon: <MessageCircle className="w-8 h-8 text-blue-500" />,
+    title: 'チャット',
+    description: 'バディと進捗を共有する',
+  },
+]
+
+export default function QuickActions() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {ACTIONS.map((action) => (
+        <Card
+          key={action.href}
+          className="hover:shadow-md transition-shadow cursor-pointer"
+        >
+          <Link href={action.href}>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  {action.icon}
+                  <div>
+                    <CardTitle className="text-base">{action.title}</CardTitle>
+                    <CardDescription>{action.description}</CardDescription>
+                  </div>
+                </div>
+                <ArrowRight className="w-4 h-4 text-muted-foreground shrink-0" />
+              </div>
+            </CardHeader>
+          </Link>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/features/home/components/StatsSection.tsx
+++ b/frontend/src/features/home/components/StatsSection.tsx
@@ -1,0 +1,157 @@
+import Link from 'next/link'
+import { TrendingUp, Users, Calendar } from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Progress } from '@/components/ui/progress'
+import type { DashboardCapacity, TodayStats } from '../types'
+
+interface StatsSectionProps {
+  capacity: DashboardCapacity | null
+  todayStats: TodayStats
+  loading: boolean
+}
+
+// --- 達成率カード ---
+
+type RateLevel = 'low' | 'mid' | 'high'
+
+function getRateLevel(rate: number): RateLevel {
+  if (rate <= 30) return 'low'
+  if (rate <= 70) return 'mid'
+  return 'high'
+}
+
+const RATE_LABEL: Record<RateLevel, string> = { low: '低', mid: '中', high: '高' }
+const RATE_COLOR: Record<RateLevel, string> = {
+  low: 'text-red-500',
+  mid: 'text-yellow-500',
+  high: 'text-green-600',
+}
+const PROGRESS_COLOR: Record<RateLevel, string> = {
+  low: '[&>div]:bg-red-500',
+  mid: '[&>div]:bg-yellow-500',
+  high: '[&>div]:bg-green-600',
+}
+
+function AchievementCard({ capacity }: { capacity: DashboardCapacity | null }) {
+  const rate = capacity ? Math.round(capacity.achievementRate * 100) : null
+  const level = rate !== null ? getRateLevel(rate) : null
+
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <div className="flex items-center gap-3 mb-3">
+          <div className="p-2 bg-primary/10 rounded-lg">
+            <TrendingUp className="w-5 h-5 text-primary" />
+          </div>
+          <p className="text-sm text-muted-foreground">直近7日の達成率</p>
+        </div>
+
+        {rate !== null && level !== null ? (
+          <>
+            <div className="flex items-baseline gap-2 mb-1">
+              <p className="text-3xl font-bold">{rate}%</p>
+              <span className={`text-xs font-medium ${RATE_COLOR[level]}`}>
+                {RATE_LABEL[level]}
+              </span>
+            </div>
+            <Progress value={rate} className={`h-2 ${PROGRESS_COLOR[level]}`} />
+            <p className="mt-2 text-xs text-muted-foreground">完了タスク / 直近7日の全タスク</p>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground mt-2">
+            タスクを1つ完了すると記録が始まります
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// --- バディカード ---
+
+function BuddyCard({ capacity }: { capacity: DashboardCapacity | null }) {
+  const isEmpty = capacity !== null && capacity.currentCount === 0
+  const isFull = capacity !== null && capacity.currentCount >= capacity.maxCount
+
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <div className="flex items-center gap-3 mb-3">
+          <div className="p-2 bg-blue-500/10 rounded-lg">
+            <Users className="w-5 h-5 text-blue-500" />
+          </div>
+          <p className="text-sm text-muted-foreground">バディ</p>
+        </div>
+
+        {capacity !== null ? (
+          <>
+            <p className="text-3xl font-bold mb-1">
+              {capacity.currentCount} / {capacity.maxCount}
+            </p>
+            {isEmpty ? (
+              <Button variant="outline" size="sm" asChild className="mt-2">
+                <Link href="/matching">バディを探す</Link>
+              </Button>
+            ) : isFull ? (
+              <p className="text-xs text-muted-foreground">上限に達しています</p>
+            ) : (
+              <p className="text-xs text-muted-foreground">上限 {capacity.maxCount}人</p>
+            )}
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground mt-2">読み込み中...</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// --- 今日のタスクカード ---
+
+function TodayTasksCard({ todayStats, loading }: { todayStats: TodayStats; loading: boolean }) {
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <div className="flex items-center gap-3 mb-3">
+          <div className="p-2 bg-green-500/10 rounded-lg">
+            <Calendar className="w-5 h-5 text-green-500" />
+          </div>
+          <p className="text-sm text-muted-foreground">今日のタスク</p>
+        </div>
+
+        {loading ? (
+          <p className="text-sm text-muted-foreground mt-2">読み込み中...</p>
+        ) : todayStats.total === 0 ? (
+          <>
+            <p className="text-3xl font-bold mb-2">0 / 0</p>
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/calendar">今日のタスクを3つ選ぶ</Link>
+            </Button>
+          </>
+        ) : (
+          <>
+            <p className="text-3xl font-bold mb-1">
+              {todayStats.completed} / {todayStats.total}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {todayStats.total}件中{todayStats.completed}件完了
+            </p>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// --- 公開コンポーネント ---
+
+export default function StatsSection({ capacity, todayStats, loading }: StatsSectionProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <AchievementCard capacity={capacity} />
+      <BuddyCard capacity={capacity} />
+      <TodayTasksCard todayStats={todayStats} loading={loading} />
+    </div>
+  )
+}

--- a/frontend/src/features/home/components/TodayTasksWidget.tsx
+++ b/frontend/src/features/home/components/TodayTasksWidget.tsx
@@ -1,0 +1,170 @@
+import Link from 'next/link'
+import { CheckCircle2, Circle, PlayCircle, Clock } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import type { TodayTask, TaskActionItemStatus } from '../types'
+
+interface TodayTasksWidgetProps {
+  tasks: TodayTask[]
+  totalCount: number
+  loading: boolean
+  onUpdateStatus: (id: string, status: TaskActionItemStatus) => Promise<void>
+}
+
+// --- 時刻フォーマット ---
+
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit', hour12: false })
+}
+
+// --- ステータス関連 ---
+
+const STATUS_BADGE: Record<
+  TaskActionItemStatus,
+  { label: string; className: string }
+> = {
+  not_started: { label: '未着手', className: 'bg-gray-100 text-gray-600' },
+  progress_30: { label: '進行中', className: 'bg-blue-100 text-blue-700' },
+  progress_70: { label: 'もうすぐ', className: 'bg-teal-100 text-teal-700' },
+  completed: { label: '完了', className: 'bg-green-100 text-green-700' },
+}
+
+function isInProgress(status: TaskActionItemStatus): boolean {
+  return status === 'progress_30' || status === 'progress_70'
+}
+
+// --- タスク行 ---
+
+interface TaskRowProps {
+  task: TodayTask
+  /** true のとき: 別タスクが進行中のため、このタスクは折りたたみ表示 */
+  subordinate: boolean
+  onUpdateStatus: (id: string, status: TaskActionItemStatus) => Promise<void>
+}
+
+function TaskRow({ task, subordinate, onUpdateStatus }: TaskRowProps) {
+  const badge = STATUS_BADGE[task.status]
+  const done = task.status === 'completed'
+
+  return (
+    <li
+      className={`flex items-center gap-3 py-3 px-1 border-b last:border-b-0 transition-opacity ${
+        subordinate ? 'opacity-40' : ''
+      }`}
+    >
+      {/* ステータスアイコン */}
+      {done ? (
+        <CheckCircle2 className="w-5 h-5 text-green-500 shrink-0" />
+      ) : isInProgress(task.status) ? (
+        <PlayCircle className="w-5 h-5 text-blue-500 shrink-0" />
+      ) : (
+        <Circle className="w-5 h-5 text-gray-300 shrink-0" />
+      )}
+
+      {/* タイトル・時刻 */}
+      <div className="flex-1 min-w-0">
+        <p
+          className={`text-sm font-medium truncate ${done ? 'line-through text-muted-foreground' : ''}`}
+        >
+          {task.title}
+        </p>
+        {!subordinate && (
+          <div className="flex items-center gap-1 mt-0.5 text-xs text-muted-foreground">
+            <Clock className="w-3 h-3" />
+            {formatTime(task.startTime)} – {formatTime(task.endTime)}
+          </div>
+        )}
+      </div>
+
+      {/* ステータスバッジ */}
+      {!subordinate && (
+        <span className={`text-xs px-2 py-0.5 rounded-full font-medium shrink-0 ${badge.className}`}>
+          {badge.label}
+        </span>
+      )}
+
+      {/* アクションボタン: 進行中タスクが存在するときは非表示 */}
+      {!subordinate && !done && (
+        <Button
+          size="sm"
+          variant={isInProgress(task.status) ? 'default' : 'outline'}
+          className="shrink-0 text-xs"
+          onClick={() =>
+            onUpdateStatus(
+              task.id,
+              task.status === 'not_started' ? 'progress_30' : 'completed'
+            )
+          }
+        >
+          {task.status === 'not_started' ? '開始する' : '完了'}
+        </Button>
+      )}
+    </li>
+  )
+}
+
+// --- メインコンポーネント ---
+
+export default function TodayTasksWidget({
+  tasks,
+  totalCount,
+  loading,
+  onUpdateStatus,
+}: TodayTasksWidgetProps) {
+  // Big3 の中で進行中タスクがあれば、他の未着手タスクを subordinate にする
+  const activeTask = tasks.find((t) => isInProgress(t.status))
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">今日の Big 3</CardTitle>
+          {totalCount > 3 && (
+            <Link
+              href="/calendar"
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              全{totalCount}件を見る →
+            </Link>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        {loading ? (
+          <div className="space-y-3 py-2">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="h-10 rounded-md bg-muted animate-pulse" />
+            ))}
+          </div>
+        ) : tasks.length === 0 ? (
+          // Empty state: CTAを第一要素に
+          <div className="py-6 text-center">
+            <p className="text-sm text-muted-foreground mb-4">
+              今日取り組む3つのタスクを選びましょう
+            </p>
+            <Button asChild>
+              <Link href="/calendar">今日のタスクを3つ選ぶ</Link>
+            </Button>
+          </div>
+        ) : (
+          <ul>
+            {tasks.map((task) => (
+              <TaskRow
+                key={task.id}
+                task={task}
+                subordinate={
+                  // 進行中タスクが存在し、かつ自分が未着手のとき折りたたむ
+                  !!activeTask &&
+                  task.id !== activeTask.id &&
+                  task.status === 'not_started'
+                }
+                onUpdateStatus={onUpdateStatus}
+              />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/features/home/hooks/useDashboard.ts
+++ b/frontend/src/features/home/hooks/useDashboard.ts
@@ -1,0 +1,195 @@
+'use client'
+
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import type {
+  DashboardCapacity,
+  DashboardProfile,
+  TodayTask,
+  TodayStats,
+  TaskActionItemStatus,
+} from '../types'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080'
+
+// --- raw API response shapes (snake_case) ---
+
+interface RawCapacity {
+  current_count: number
+  max_count: number
+  achievement_rate: number
+}
+
+interface RawProfile {
+  goal_types: string[]
+  bio: string
+}
+
+interface RawActionItem {
+  uuid: string
+  title: string
+  status: TaskActionItemStatus
+  kind: string
+  start_time: string
+  end_time: string
+}
+
+// --- 定数 ---
+
+/** ステータスの表示優先度（低い数値が先） */
+const STATUS_PRIORITY: Record<TaskActionItemStatus, number> = {
+  not_started: 0,
+  progress_30: 1,
+  progress_70: 2,
+  completed: 3,
+}
+
+// --- ユーティリティ ---
+
+function getTodayRange(): { start: Date; end: Date } {
+  const start = new Date()
+  start.setHours(0, 0, 0, 0)
+  const end = new Date()
+  end.setHours(23, 59, 59, 999)
+  return { start, end }
+}
+
+function mapToTodayTask(item: RawActionItem): TodayTask {
+  return {
+    id: item.uuid,
+    title: item.title,
+    startTime: new Date(item.start_time),
+    endTime: new Date(item.end_time),
+    status: item.status,
+  }
+}
+
+/**
+ * 今日のタスク一覧を優先度順・期限順でソートして上位3件を返す。
+ * ソート: not_started → progress_30/70 → completed の順、同ステータス内は期限が近い順。
+ */
+function computeBig3(tasks: TodayTask[]): TodayTask[] {
+  return [...tasks]
+    .sort((a, b) => {
+      const pd = STATUS_PRIORITY[a.status] - STATUS_PRIORITY[b.status]
+      if (pd !== 0) return pd
+      return a.endTime.getTime() - b.endTime.getTime()
+    })
+    .slice(0, 3)
+}
+
+// --- フック ---
+
+export interface UseDashboardReturn {
+  capacity: DashboardCapacity | null
+  profile: DashboardProfile | null
+  /** 表示優先度順・期限順のトップ3タスク */
+  big3: TodayTask[]
+  /** 今日の全タスク集計（Big3 外のものも含む） */
+  todayStats: TodayStats
+  loading: boolean
+  /**
+   * タスクのステータスを楽観的更新で変更する。
+   * API失敗時は自動的にロールバックする。
+   */
+  updateTaskStatus: (id: string, newStatus: TaskActionItemStatus) => Promise<void>
+}
+
+export function useDashboard(): UseDashboardReturn {
+  const [tasks, setTasks] = useState<TodayTask[]>([])
+  const [capacity, setCapacity] = useState<DashboardCapacity | null>(null)
+  const [profile, setProfile] = useState<DashboardProfile | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const { start, end } = getTodayRange()
+
+    const fetchCapacity = fetch(`${API_BASE}/api/buddy/capacity`, {
+      credentials: 'include',
+    })
+      .then((r) => (r.ok ? (r.json() as Promise<RawCapacity>) : null))
+      .then((d) => {
+        if (!d) return
+        setCapacity({
+          currentCount: d.current_count,
+          maxCount: d.max_count,
+          achievementRate: d.achievement_rate,
+        })
+      })
+      .catch(() => null)
+
+    const fetchProfile = fetch(`${API_BASE}/api/buddy/profile`, {
+      credentials: 'include',
+    })
+      .then((r) => (r.ok ? (r.json() as Promise<RawProfile>) : null))
+      .then((d) => {
+        if (!d) return
+        setProfile({ goalTypes: d.goal_types, bio: d.bio })
+      })
+      .catch(() => null)
+
+    const fetchTasks = fetch(`${API_BASE}/api/v1/action-items`, {
+      credentials: 'include',
+    })
+      .then((r) => (r.ok ? (r.json() as Promise<{ data: RawActionItem[] }>) : null))
+      .then((body) => {
+        if (!body?.data) return
+        const todayTasks = body.data
+          .filter((item) => {
+            if (item.kind === 'break') return false
+            const t = new Date(item.start_time)
+            return t >= start && t <= end
+          })
+          .map(mapToTodayTask)
+        setTasks(todayTasks)
+      })
+      .catch(() => null)
+
+    Promise.allSettled([fetchCapacity, fetchProfile, fetchTasks]).then(() =>
+      setLoading(false)
+    )
+  }, [])
+
+  const big3 = useMemo(() => computeBig3(tasks), [tasks])
+
+  const todayStats = useMemo(
+    (): TodayStats => ({
+      total: tasks.length,
+      // progress_70 も「ほぼ完了」として完了扱いにする（既存ロジックを踏襲）
+      completed: tasks.filter(
+        (t) => t.status === 'completed' || t.status === 'progress_70'
+      ).length,
+    }),
+    [tasks]
+  )
+
+  const updateTaskStatus = useCallback(
+    async (id: string, newStatus: TaskActionItemStatus): Promise<void> => {
+      // 楽観的更新：setTasks 内でロールバック用の元ステータスを取得
+      let previousStatus: TaskActionItemStatus | null = null
+      setTasks((prev) => {
+        const task = prev.find((t) => t.id === id)
+        if (task) previousStatus = task.status
+        return prev.map((t) => (t.id === id ? { ...t, status: newStatus } : t))
+      })
+
+      try {
+        const res = await fetch(`${API_BASE}/api/v1/action-items/${id}`, {
+          method: 'PUT',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: newStatus }),
+        })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      } catch {
+        // API 失敗時はロールバック
+        if (previousStatus !== null) {
+          const ps = previousStatus
+          setTasks((prev) => prev.map((t) => (t.id === id ? { ...t, status: ps } : t)))
+        }
+      }
+    },
+    []
+  )
+
+  return { capacity, profile, big3, todayStats, loading, updateTaskStatus }
+}

--- a/frontend/src/features/home/index.ts
+++ b/frontend/src/features/home/index.ts
@@ -1,3 +1,11 @@
 // Home Featureのエントリーポイント
 // 他FeatureやApp RouterからHomeMainをimportするための再エクスポート
 export { default as HomeMain } from './components/HomeMain'
+export { useDashboard } from './hooks/useDashboard'
+export type {
+  TodayTask,
+  DashboardCapacity,
+  DashboardProfile,
+  TodayStats,
+  TaskActionItemStatus,
+} from './types'

--- a/frontend/src/features/home/types/index.ts
+++ b/frontend/src/features/home/types/index.ts
@@ -1,0 +1,33 @@
+import type { TaskActionItemStatus } from '@/client/types.gen'
+
+export type { TaskActionItemStatus }
+
+/** 今日のアクションアイテム（ダッシュボード表示用） */
+export interface TodayTask {
+  id: string
+  title: string
+  startTime: Date
+  endTime: Date
+  status: TaskActionItemStatus
+}
+
+/** バディ枠情報 */
+export interface DashboardCapacity {
+  currentCount: number
+  maxCount: number
+  /** 0–1 の割合 */
+  achievementRate: number
+}
+
+/** プロフィール情報 */
+export interface DashboardProfile {
+  goalTypes: string[]
+  bio: string
+}
+
+/** 今日のタスク集計 */
+export interface TodayStats {
+  total: number
+  /** completed または progress_70 を「完了」扱い */
+  completed: number
+}


### PR DESCRIPTION
- グリーティングを時間帯別挨拶＋日付＋状況サマリ行に変更
- StatsSection: 空状態を 0 表示から次の行動 CTA に置き換え
- TodayTasksWidget: Big 3 表示 + 開始/完了ボタン + Single-tasking 支援
- BuddyWidget: バディ一覧に「進捗を共有」「チャット」行動ボタンを追加
- QuickActions: 「カレンダー」→「今日のタスクを追加」に変更、チャットを追加
- useDashboard フックに楽観的更新（失敗時ロールバック）を実装

Phase 別の変更ポイント
Phase 1 — Empty State → CTA化

StatsSection: 0件のとき「今日のタスクを3つ選ぶ」「バディを探す」ボタンを第一要素として表示
DashboardGreeting: 時間帯別挨拶（おはよう/こんにちは/こんばんは）+ 日付 + 状況サマリ行
Phase 2 — Big 3 ウィジェット

TodayTasksWidget: 未着手→進行中→完了の優先度順に上位3件を表示
「開始する」で progress_30 へ、「完了」で completed へ楽観的更新（API失敗時は自動ロールバック）
進行中タスクがある間、他の未着手タスクは opacity-40 で折りたたみ（Single-tasking支援）
Phase 3 — 状況サマリ + クイックアクション刷新

DashboardGreeting: 1行で今日の状況（タスク3件 · 1件完了）を表示
QuickActions: 「カレンダー」→「今日のタスクを追加」、チャットを3枚目に追加
Phase 4 — バディUIに行動ボタン

BuddyWidget: イニシャルアバター + 「進捗を共有」「チャット」ボタン（roomId付きリンク）
達成率カードに「低/中/高」ラベルと色を追加（[&>div]:bg-red-500 で Tailwind v4対応）
アーキテクチャ上の判断
useDashboard に全データ取得を集約し、HomeMain はコンポーネントの組み合わせのみ担当
楽観的更新は setTasks の updater 関数内で前状態をキャプチャしてロールバック
Big 3 は useMemo で導出（再ソートあり）、ウィジェット内では statusが変わっても表示順は安定
<img width="737" height="323" alt="スクリーンショット 2026-03-31 23 57 08" src="https://github.com/user-attachments/assets/2061f736-ffea-4a80-89d7-093f88c745fb" />
