### PR TITLE
feat(ui): フロントエンドUI全面刷新・ダッシュボード機能追加

### DIFF
--- a/frontend/src/app/(app)/buddies/page.tsx
+++ b/frontend/src/app/(app)/buddies/page.tsx
@@ -2,7 +2,7 @@
 import { useBuddies } from '@/features/buddies/hooks/useBuddies'
 import { BuddyCard } from '@/features/buddies/components/BuddyCard'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
+import { Card } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Users, UserPlus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
@@ -16,93 +16,96 @@ export default function Buddies() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="max-w-6xl mx-auto">
-        <div className="flex items-center justify-between mb-8">
-          <h1 className="text-3xl font-bold">バディ・フレンド</h1>
-          <Button onClick={() => router.push('/matching')}>
-            <UserPlus className="w-4 h-4 mr-2" />
-            新しいバディを探す
-          </Button>
+    <div className="container mx-auto px-4 py-6 max-w-4xl">
+      <div className="flex items-center justify-between mb-5">
+        <div>
+          <h1 className="text-xl font-semibold">バディ・フレンド</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">一緒に目標達成を目指す仲間</p>
         </div>
+        <Button size="sm" onClick={() => router.push('/matching')}>
+          <UserPlus className="w-3.5 h-3.5 mr-1.5" />
+          バディを探す
+        </Button>
+      </div>
 
-        {error && (
-          <div className="mb-4 p-3 text-sm text-red-600 bg-red-50 rounded">
-            {error}
-          </div>
-        )}
-        {loading && (
-          <div className="mb-4 p-3 text-sm text-muted-foreground">
-            読み込み中...
-          </div>
-        )}
+      {error && (
+        <div className="mb-4 px-4 py-3 text-sm text-red-600 bg-red-50 rounded-lg">
+          {error}
+        </div>
+      )}
+      {loading && (
+        <div className="mb-4 text-sm text-muted-foreground">読み込み中...</div>
+      )}
 
-        <Tabs defaultValue="buddies">
-          <TabsList className="grid w-full grid-cols-2 mb-6">
-            <TabsTrigger value="buddies">バディ ({buddies.length})</TabsTrigger>
-            <TabsTrigger value="friends">フレンド</TabsTrigger>
-          </TabsList>
+      <Tabs defaultValue="buddies">
+        <TabsList className="grid w-full grid-cols-2 mb-5">
+          <TabsTrigger value="buddies">バディ ({buddies.length})</TabsTrigger>
+          <TabsTrigger value="friends">フレンド</TabsTrigger>
+        </TabsList>
 
-          <TabsContent value="buddies">
-            {!loading && buddies.length === 0 ? (
-              <Card>
-                <CardContent className="flex flex-col items-center justify-center py-16">
-                  <Users className="w-16 h-16 text-muted-foreground mb-4" />
-                  <h3 className="text-xl font-semibold mb-2">バディがいません</h3>
-                  <p className="text-muted-foreground mb-6 text-center">
-                    新しいバディを探して、一緒に目標達成を目指しましょう
-                  </p>
-                  <Button onClick={() => router.push('/matching')}>
-                    <UserPlus className="w-4 h-4 mr-2" />
-                    バディを探す
-                  </Button>
-                </CardContent>
-              </Card>
-            ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {buddies.map((buddy) => (
-                  <BuddyCard
-                    key={buddy.id}
-                    buddy={buddy}
-                    onOpenChat={handleOpenChat}
-                  />
-                ))}
-              </div>
-            )}
-          </TabsContent>
-
-          <TabsContent value="friends">
+        <TabsContent value="buddies">
+          {!loading && buddies.length === 0 ? (
             <Card>
-              <CardContent className="flex flex-col items-center justify-center py-16">
-                <Users className="w-16 h-16 text-muted-foreground mb-4" />
-                <h3 className="text-xl font-semibold mb-2">準備中</h3>
-                <p className="text-muted-foreground text-center">
-                  バディ期間を終えた相手とフレンドになる機能は近日公開予定です
+              <div className="flex flex-col items-center justify-center py-12 px-5">
+                <div className="w-12 h-12 bg-muted rounded-full flex items-center justify-center mb-3">
+                  <Users className="w-6 h-6 text-muted-foreground" />
+                </div>
+                <p className="font-medium mb-1">バディがいません</p>
+                <p className="text-sm text-muted-foreground mb-4 text-center">
+                  新しいバディを探して、一緒に目標達成を目指しましょう
                 </p>
-              </CardContent>
+                <Button size="sm" onClick={() => router.push('/matching')}>
+                  <UserPlus className="w-3.5 h-3.5 mr-1.5" />
+                  バディを探す
+                </Button>
+              </div>
             </Card>
-          </TabsContent>
-        </Tabs>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {buddies.map((buddy) => (
+                <BuddyCard
+                  key={buddy.id}
+                  buddy={buddy}
+                  onOpenChat={handleOpenChat}
+                />
+              ))}
+            </div>
+          )}
+        </TabsContent>
 
-        <Card className="mt-8">
-          <CardContent className="py-6">
-            <h3 className="font-semibold mb-3">バディ・フレンドについて</h3>
-            <div className="space-y-2 text-sm text-muted-foreground">
-              <p>
-                <span className="font-semibold text-foreground">バディ：</span>
-                マッチング後の1週間、互いのAction Itemを共有し、もくもく会を実施する相手です。
-              </p>
-              <p>
-                <span className="font-semibold text-foreground">フレンド：</span>
-                バディ期間を終えた後、継続的に一緒に頑張りたい相手です。
-              </p>
-              <p className="mt-3 text-xs">
-                ※ 同時にバディになれる人数は、あなたの達成率に応じて増えます。
+        <TabsContent value="friends">
+          <Card>
+            <div className="flex flex-col items-center justify-center py-12 px-5">
+              <div className="w-12 h-12 bg-muted rounded-full flex items-center justify-center mb-3">
+                <Users className="w-6 h-6 text-muted-foreground" />
+              </div>
+              <p className="font-medium mb-1">準備中</p>
+              <p className="text-sm text-muted-foreground text-center">
+                バディ期間を終えた相手とフレンドになる機能は近日公開予定です
               </p>
             </div>
-          </CardContent>
-        </Card>
-      </div>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      <Card className="mt-5">
+        <div className="px-4 py-4">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-3">バディ・フレンドについて</p>
+          <div className="space-y-2 text-sm text-muted-foreground">
+            <p>
+              <span className="font-medium text-foreground">バディ：</span>
+              マッチング後の1週間、互いのAction Itemを共有し、もくもく会を実施する相手です。
+            </p>
+            <p>
+              <span className="font-medium text-foreground">フレンド：</span>
+              バディ期間を終えた後、継続的に一緒に頑張りたい相手です。
+            </p>
+            <p className="text-xs mt-2">
+              ※ 同時にバディになれる人数は、あなたの達成率に応じて増えます。
+            </p>
+          </div>
+        </div>
+      </Card>
     </div>
   )
 }

--- a/frontend/src/app/(app)/calendar/page.tsx
+++ b/frontend/src/app/(app)/calendar/page.tsx
@@ -29,7 +29,7 @@ export default function Calendar() {
   } = useCalendar()
 
   return (
-    <div className="flex flex-col h-screen p-4">
+    <div className="flex flex-col h-[calc(100vh-57px)] p-3 md:p-4">
       {error && (
         <div className="mb-2 p-2 text-sm text-red-600 bg-red-50 rounded">
           {error}

--- a/frontend/src/app/(app)/calendar/page.tsx
+++ b/frontend/src/app/(app)/calendar/page.tsx
@@ -29,7 +29,7 @@ export default function Calendar() {
   } = useCalendar()
 
   return (
-    <div className="flex flex-col h-[calc(100vh-57px)] p-3 md:p-4">
+    <div className="flex flex-col h-[calc(100vh-56px)] p-3 md:p-4">
       {error && (
         <div className="mb-2 p-2 text-sm text-red-600 bg-red-50 rounded">
           {error}

--- a/frontend/src/app/(app)/chat/page.tsx
+++ b/frontend/src/app/(app)/chat/page.tsx
@@ -5,8 +5,9 @@ import { useSearchParams } from 'next/navigation'
 import { useChat } from '@/features/chat/hooks/useChat'
 import { ChatRoomList } from '@/features/chat/components/ChatRoomList'
 import { ChatWindow } from '@/features/chat/components/ChatWindow'
-import { Card, CardContent } from '@/components/ui/card'
-import { MessageSquare } from 'lucide-react'
+import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { MessageSquare, ArrowLeft } from 'lucide-react'
 
 function ChatContent() {
   const searchParams = useSearchParams()
@@ -14,15 +15,14 @@ function ChatContent() {
 
   const { chatRooms, currentUserId, wsURL, fetchMessages, addMessage, getMessages } = useChat()
 
-  // ?room=<uuid> でルームを初期選択
   useEffect(() => {
     const roomParam = searchParams.get('room')
     if (roomParam) {
       setSelectedRoomId(roomParam)
+      fetchMessages(roomParam)
     }
   }, [searchParams])
 
-  // ルーム選択時にメッセージ履歴を取得
   const handleSelectRoom = (roomId: string) => {
     setSelectedRoomId(roomId)
     fetchMessages(roomId)
@@ -32,12 +32,12 @@ function ChatContent() {
   const messages = selectedRoomId ? getMessages(selectedRoomId) : []
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8">チャット</h1>
+    <div className="container mx-auto px-4 py-4 md:py-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div className="md:col-span-1">
-          <h2 className="text-xl font-semibold mb-4">チャットルーム</h2>
+        {/* ルーム一覧: モバイルでは会話選択中は非表示 */}
+        <div className={`md:col-span-1 ${selectedRoomId ? 'hidden md:block' : 'block'}`}>
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-3">チャットルーム</p>
           <ChatRoomList
             rooms={chatRooms}
             onSelectRoom={handleSelectRoom}
@@ -45,27 +45,39 @@ function ChatContent() {
           />
         </div>
 
-        <div className="md:col-span-2">
+        {/* 会話ウィンドウ: モバイルでは会話選択中のみ表示 */}
+        <div className={`md:col-span-2 ${selectedRoomId ? 'block' : 'hidden md:block'}`}>
           {selectedRoom && selectedRoomId ? (
-            <ChatWindow
-              roomId={selectedRoomId}
-              participantName={selectedRoom.participantName}
-              messages={messages}
-              currentUserId={currentUserId}
-              onReceiveMessage={addMessage}
-              wsURL={wsURL}
-            />
+            <div className="flex flex-col gap-2">
+              {/* モバイル用の戻るボタン */}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="md:hidden self-start -ml-2 text-muted-foreground"
+                onClick={() => setSelectedRoomId(undefined)}
+              >
+                <ArrowLeft className="w-4 h-4 mr-1" />
+                ルーム一覧
+              </Button>
+              <ChatWindow
+                roomId={selectedRoomId}
+                participantName={selectedRoom.participantName}
+                messages={messages}
+                currentUserId={currentUserId}
+                onReceiveMessage={addMessage}
+                wsURL={wsURL}
+              />
+            </div>
           ) : (
-            <Card className="h-[600px]">
-              <CardContent className="flex flex-col items-center justify-center h-full">
-                <MessageSquare className="w-16 h-16 text-muted-foreground mb-4" />
-                <p className="text-muted-foreground">
-                  チャットルームを選択してください
-                </p>
-              </CardContent>
+            <Card className="hidden md:flex h-[600px] items-center justify-center">
+              <div className="flex flex-col items-center text-muted-foreground">
+                <MessageSquare className="w-12 h-12 mb-3 opacity-40" />
+                <p className="text-sm">チャットルームを選択してください</p>
+              </div>
             </Card>
           )}
         </div>
+
       </div>
     </div>
   )

--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -1,20 +1,48 @@
 import type { ReactNode } from 'react'
+import { Users } from 'lucide-react'
 
 export default function AuthLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-background p-4">
-      <div className="mb-8 text-center">
-        <div className="inline-flex items-center justify-center w-14 h-14 bg-primary rounded-2xl shadow-md mb-4">
-          <svg className="w-8 h-8 text-primary-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
-          </svg>
+    <div className="min-h-screen md:grid md:grid-cols-2">
+
+      {/* Left: Brand hero — desktop only */}
+      <div className="hidden md:flex flex-col justify-between bg-primary p-12 text-primary-foreground overflow-hidden relative">
+        {/* Decorative circles */}
+        <div className="absolute -top-20 -right-20 w-64 h-64 bg-white/8 rounded-full" />
+        <div className="absolute bottom-20 -left-12 w-40 h-40 bg-white/6 rounded-full" />
+
+        <div className="relative flex items-center gap-2.5">
+          <div className="w-8 h-8 bg-white/15 rounded-xl flex items-center justify-center backdrop-blur-sm">
+            <Users className="w-4.5 h-4.5" />
+          </div>
+          <span className="font-semibold tracking-tight">ActBuddy</span>
         </div>
-        <h1 className="text-2xl font-semibold tracking-tight">ActBuddy</h1>
-        <p className="text-muted-foreground mt-1 text-sm">
-          行動を起こすきっかけを、一緒に。
-        </p>
+
+        <div className="relative">
+          <p className="text-3xl font-bold leading-snug mb-4">
+            行動することを、<br />一人で諦めない。
+          </p>
+          <p className="text-primary-foreground/60 text-sm leading-relaxed">
+            目標を持つ仲間と出会い、<br />互いの行動を支え合う場所。
+          </p>
+        </div>
+
+        <p className="relative text-xs text-primary-foreground/35">© 2025 ActBuddy</p>
       </div>
-      {children}
+
+      {/* Right: Form area */}
+      <div className="flex flex-col items-center justify-center min-h-screen md:min-h-0 px-6 py-12">
+        {/* Mobile brand */}
+        <div className="md:hidden mb-10 text-center">
+          <div className="inline-flex items-center justify-center w-12 h-12 bg-primary rounded-2xl shadow-md mb-3">
+            <Users className="w-6 h-6 text-primary-foreground" />
+          </div>
+          <h1 className="text-lg font-semibold">ActBuddy</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">行動を起こすきっかけを、一緒に。</p>
+        </div>
+
+        {children}
+      </div>
     </div>
   )
 }

--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -4,8 +4,13 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-background p-4">
       <div className="mb-8 text-center">
-        <h1 className="text-3xl font-bold">ActBuddy</h1>
-        <p className="text-muted-foreground mt-1">
+        <div className="inline-flex items-center justify-center w-14 h-14 bg-primary rounded-2xl shadow-md mb-4">
+          <svg className="w-8 h-8 text-primary-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        </div>
+        <h1 className="text-2xl font-semibold tracking-tight">ActBuddy</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
           行動を起こすきっかけを、一緒に。
         </p>
       </div>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -48,38 +48,39 @@
 }
 
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --radius: 0.875rem;
+  /* 温かみのあるクリーム × セージグリーン */
+  --background: oklch(0.978 0.012 78);
+  --foreground: oklch(0.22 0.025 60);
+  --card: oklch(0.996 0.007 78);
+  --card-foreground: oklch(0.22 0.025 60);
+  --popover: oklch(0.996 0.007 78);
+  --popover-foreground: oklch(0.22 0.025 60);
+  --primary: oklch(0.50 0.11 147);
+  --primary-foreground: oklch(0.985 0.006 80);
+  --secondary: oklch(0.935 0.018 78);
+  --secondary-foreground: oklch(0.28 0.02 60);
+  --muted: oklch(0.94 0.013 78);
+  --muted-foreground: oklch(0.50 0.025 75);
+  --accent: oklch(0.935 0.02 78);
+  --accent-foreground: oklch(0.28 0.02 60);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --border: oklch(0.885 0.016 78);
+  --input: oklch(0.885 0.016 78);
+  --ring: oklch(0.50 0.11 147);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar: oklch(0.968 0.014 78);
+  --sidebar-foreground: oklch(0.22 0.025 60);
+  --sidebar-primary: oklch(0.50 0.11 147);
+  --sidebar-primary-foreground: oklch(0.985 0.006 80);
+  --sidebar-accent: oklch(0.935 0.018 78);
+  --sidebar-accent-foreground: oklch(0.28 0.02 60);
+  --sidebar-border: oklch(0.885 0.016 78);
+  --sidebar-ring: oklch(0.50 0.11 147);
 }
 
 .dark {
@@ -122,7 +123,14 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-feature-settings: 'palt';
   }
+}
+
+/* カードに柔らかいシャドウ */
+[data-slot='card'] {
+  box-shadow: 0 1px 4px oklch(0.22 0.025 60 / 0.06), 0 0 0 1px oklch(0.885 0.016 78);
+  border: none;
 }
 
 /* react-big-calendar 現在時刻インジケーター */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -49,38 +49,37 @@
 
 :root {
   --radius: 0.875rem;
-  /* 温かみのあるクリーム × セージグリーン */
-  --background: oklch(0.978 0.012 78);
-  --foreground: oklch(0.22 0.025 60);
-  --card: oklch(0.996 0.007 78);
-  --card-foreground: oklch(0.22 0.025 60);
-  --popover: oklch(0.996 0.007 78);
-  --popover-foreground: oklch(0.22 0.025 60);
-  --primary: oklch(0.50 0.11 147);
-  --primary-foreground: oklch(0.985 0.006 80);
-  --secondary: oklch(0.935 0.018 78);
-  --secondary-foreground: oklch(0.28 0.02 60);
-  --muted: oklch(0.94 0.013 78);
-  --muted-foreground: oklch(0.50 0.025 75);
-  --accent: oklch(0.935 0.02 78);
-  --accent-foreground: oklch(0.28 0.02 60);
+  --background: oklch(0.972 0.014 75);
+  --foreground: oklch(0.16 0.03 55);
+  --card: oklch(0.999 0.004 80);
+  --card-foreground: oklch(0.16 0.03 55);
+  --popover: oklch(0.999 0.004 80);
+  --popover-foreground: oklch(0.16 0.03 55);
+  --primary: oklch(0.43 0.14 155);
+  --primary-foreground: oklch(0.985 0.005 80);
+  --secondary: oklch(0.935 0.016 75);
+  --secondary-foreground: oklch(0.25 0.025 60);
+  --muted: oklch(0.938 0.013 75);
+  --muted-foreground: oklch(0.48 0.025 72);
+  --accent: oklch(0.935 0.018 75);
+  --accent-foreground: oklch(0.25 0.025 60);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.885 0.016 78);
-  --input: oklch(0.885 0.016 78);
-  --ring: oklch(0.50 0.11 147);
+  --border: oklch(0.882 0.014 75);
+  --input: oklch(0.882 0.014 75);
+  --ring: oklch(0.43 0.14 155);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.968 0.014 78);
-  --sidebar-foreground: oklch(0.22 0.025 60);
-  --sidebar-primary: oklch(0.50 0.11 147);
-  --sidebar-primary-foreground: oklch(0.985 0.006 80);
-  --sidebar-accent: oklch(0.935 0.018 78);
-  --sidebar-accent-foreground: oklch(0.28 0.02 60);
-  --sidebar-border: oklch(0.885 0.016 78);
-  --sidebar-ring: oklch(0.50 0.11 147);
+  --sidebar: oklch(0.968 0.014 75);
+  --sidebar-foreground: oklch(0.16 0.03 55);
+  --sidebar-primary: oklch(0.43 0.14 155);
+  --sidebar-primary-foreground: oklch(0.985 0.005 80);
+  --sidebar-accent: oklch(0.935 0.016 75);
+  --sidebar-accent-foreground: oklch(0.25 0.025 60);
+  --sidebar-border: oklch(0.882 0.014 75);
+  --sidebar-ring: oklch(0.43 0.14 155);
 }
 
 .dark {
@@ -90,8 +89,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: oklch(0.62 0.14 155);
+  --primary-foreground: oklch(0.985 0.005 80);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
@@ -101,7 +100,7 @@
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --ring: oklch(0.62 0.14 155);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
@@ -109,12 +108,12 @@
   --chart-5: oklch(0.645 0.246 16.439);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary: oklch(0.62 0.14 155);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar-ring: oklch(0.62 0.14 155);
 }
 
 @layer base {
@@ -127,27 +126,29 @@
   }
 }
 
-/* カードに柔らかいシャドウ */
+/* カードに精緻なシャドウ */
 [data-slot='card'] {
-  box-shadow: 0 1px 4px oklch(0.22 0.025 60 / 0.06), 0 0 0 1px oklch(0.885 0.016 78);
-  border: none;
+  box-shadow:
+    0 1px 3px oklch(0.16 0.03 55 / 0.06),
+    0 1px 2px oklch(0.16 0.03 55 / 0.04);
+  border: 1px solid oklch(0.882 0.014 75 / 0.7);
 }
 
 /* react-big-calendar 現在時刻インジケーター */
 .rbc-current-time-indicator {
-  height: 3px;
-  background-color: #ef4444;
+  height: 2px;
+  background-color: oklch(0.43 0.14 155);
   opacity: 1;
 }
 
 .rbc-current-time-indicator::before {
   content: '';
   position: absolute;
-  left: -5px;
+  left: -4px;
   top: 50%;
   transform: translateY(-50%);
-  width: 11px;
-  height: 11px;
+  width: 9px;
+  height: 9px;
   border-radius: 50%;
-  background-color: #ef4444;
+  background-color: oklch(0.43 0.14 155);
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from 'next'
-import { Geist, Geist_Mono } from 'next/font/google'
+import { Noto_Sans_JP, Geist_Mono } from 'next/font/google'
 import './globals.css'
 
-const geistSans = Geist({
+const notoSansJP = Noto_Sans_JP({
   variable: '--font-geist-sans',
   subsets: ['latin'],
+  weight: ['400', '500', '700'],
+  display: 'swap',
 })
 
 const geistMono = Geist_Mono({
@@ -25,7 +27,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${notoSansJP.variable} ${geistMono.variable} antialiased`}
       >
         {children}
       </body>

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -132,7 +132,7 @@ export function Header() {
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button className="w-7 h-7 rounded-full bg-primary/15 text-primary flex items-center justify-center text-xs font-semibold hover:bg-primary/25 transition-colors ml-1">
-                  {mounted ? (currentUser?.display_name.charAt(0) ?? '?') : '?'}
+                  {mounted ? (currentUser?.display_name?.[0] ?? '?') : '?'}
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-44">

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -86,14 +86,14 @@ export function Header() {
         />
       )}
 
-      <header className="border-b bg-background relative z-20">
-        <div className="container mx-auto px-4 py-4">
+      <header className="border-b border-border/60 bg-card/80 backdrop-blur-sm relative z-20">
+        <div className="container mx-auto px-4 py-3">
           <div className="flex items-center justify-between">
-            <Link href="/dashboard" className="flex items-center gap-2">
-              <div className="w-10 h-10 bg-primary rounded-lg flex items-center justify-center">
-                <Users className="w-6 h-6 text-primary-foreground" />
+            <Link href="/dashboard" className="flex items-center gap-2.5">
+              <div className="w-9 h-9 bg-primary rounded-xl flex items-center justify-center shadow-sm">
+                <Users className="w-5 h-5 text-primary-foreground" />
               </div>
-              <span className="text-xl font-bold">ActBuddy</span>
+              <span className="text-lg font-semibold tracking-tight">ActBuddy</span>
             </Link>
 
             {/* Desktop Navigation */}

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -24,7 +24,7 @@ import {
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useCurrentUser } from '@/features/auth/hooks/useCurrentUser'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 
 interface NavItem {
   href: string
@@ -33,21 +33,9 @@ interface NavItem {
 }
 
 const NAV_ITEMS: NavItem[] = [
-  {
-    href: '/calendar',
-    label: 'カレンダー',
-    icon: Calendar,
-  },
-  {
-    href: '/buddies',
-    label: 'バディ',
-    icon: UserCircle,
-  },
-  {
-    href: '/matching',
-    label: 'マッチング',
-    icon: Users,
-  },
+  { href: '/calendar',  label: 'カレンダー', icon: Calendar  },
+  { href: '/buddies',   label: 'バディ',     icon: UserCircle },
+  { href: '/matching',  label: 'マッチング', icon: Users      },
 ]
 
 const MOCK_NOTIFICATION_COUNT = 0
@@ -58,12 +46,12 @@ const API_BASE_URL =
 export function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const [mounted, setMounted] = useState(false)
-  const router = useRouter()
+  const router   = useRouter()
+  const pathname = usePathname()
+
   const { user: currentUser } = useCurrentUser()
 
-  useEffect(() => {
-    setMounted(true)
-  }, [])
+  useEffect(() => { setMounted(true) }, [])
 
   const handleLogout = async () => {
     await fetch(`${API_BASE_URL}/api/auth/logout`, {
@@ -75,151 +63,132 @@ export function Header() {
     router.push('/login')
   }
 
-
   return (
     <>
-      {/* Mobile Menu Overlay */}
       {isMobileMenuOpen && (
         <div
-          className="fixed inset-0 z-10 bg-black/50 md:hidden"
+          className="fixed inset-0 z-10 bg-black/30 backdrop-blur-sm md:hidden"
           onClick={() => setIsMobileMenuOpen(false)}
         />
       )}
 
-      <header className="border-b border-border/60 bg-card/80 backdrop-blur-sm relative z-20">
-        <div className="container mx-auto px-4 py-3">
-          <div className="flex items-center justify-between">
-            <Link href="/dashboard" className="flex items-center gap-2.5">
-              <div className="w-9 h-9 bg-primary rounded-xl flex items-center justify-center shadow-sm">
-                <Users className="w-5 h-5 text-primary-foreground" />
-              </div>
-              <span className="text-lg font-semibold tracking-tight">ActBuddy</span>
+      <header className="sticky top-0 z-20 h-14 bg-background/80 backdrop-blur-xl border-b border-border/50">
+        <div className="max-w-6xl mx-auto px-4 h-full flex items-center justify-between">
+
+          {/* Logo */}
+          <Link href="/dashboard" className="flex items-center gap-2 shrink-0">
+            <div className="w-7 h-7 bg-primary rounded-lg flex items-center justify-center shadow-sm">
+              <Users className="w-4 h-4 text-primary-foreground" />
+            </div>
+            <span className="font-semibold text-sm tracking-tight">ActBuddy</span>
+          </Link>
+
+          {/* Desktop Nav */}
+          <nav className="hidden md:flex items-center gap-0.5">
+            {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+              const active = pathname.startsWith(href)
+              return (
+                <Link
+                  key={href}
+                  href={href}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm transition-colors ${
+                    active
+                      ? 'bg-primary/10 text-primary font-medium'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+                  }`}
+                >
+                  <Icon className="w-3.5 h-3.5" />
+                  {label}
+                </Link>
+              )
+            })}
+          </nav>
+
+          {/* Right */}
+          <div className="flex items-center gap-1">
+            {/* Notifications */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button className="relative p-2 rounded-lg hover:bg-accent transition-colors">
+                  <Bell className="w-4 h-4" />
+                  {MOCK_NOTIFICATION_COUNT > 0 && (
+                    <span className="absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full" />
+                  )}
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+                  {MOCK_NOTIFICATION_COUNT === 0 ? '通知はありません' : `${MOCK_NOTIFICATION_COUNT}件の通知`}
+                </DropdownMenuLabel>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            {/* Chat */}
+            <Link href="/chat" className="p-2 rounded-lg hover:bg-accent transition-colors">
+              <Mail className="w-4 h-4" />
             </Link>
 
-            {/* Desktop Navigation */}
-            <nav className="hidden md:block">
-              <ul className="flex gap-2">
-                {NAV_ITEMS.map(({ href, label, icon: Icon }) => (
-                  <li key={href}>
-                    <Button variant="ghost" asChild>
-                      <Link href={href}>
-                        <Icon className="w-4 h-4 mr-2" />
-                        {label}
-                      </Link>
-                    </Button>
-                  </li>
-                ))}
-              </ul>
-            </nav>
-
-            {/* Right side UI area */}
-            <div className="flex items-center gap-2 md:gap-4">
-              {/* Notification Bell */}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <div className="relative inline-flex">
-                    <button className="p-2 hover:bg-accent rounded-lg transition-colors flex items-center justify-center">
-                      <Bell className="w-5 h-5" />
-                    </button>
-                    {MOCK_NOTIFICATION_COUNT > 0 && (
-                      <span className="absolute -top-1 -right-1 min-w-5 h-5 bg-red-500 text-white text-xs rounded-full flex items-center justify-center leading-none font-bold">
-                        {MOCK_NOTIFICATION_COUNT > 9
-                          ? '9+'
-                          : MOCK_NOTIFICATION_COUNT}
-                      </span>
-                    )}
-                  </div>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuLabel>
-                    {MOCK_NOTIFICATION_COUNT === 0
-                      ? '通知がありません'
-                      : `未読通知が ${MOCK_NOTIFICATION_COUNT} 件あります`}
-                  </DropdownMenuLabel>
-                  {MOCK_NOTIFICATION_COUNT > 0 && (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem>
-                        通知一覧を見る
-                      </DropdownMenuItem>
-                    </>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
-
-              {/* Message Mail */}
-              <div className="relative inline-flex">
-                <Link
-                  href="/chat"
-                  className="p-2 hover:bg-accent rounded-lg transition-colors flex items-center justify-center"
+            {/* User */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button className="w-7 h-7 rounded-full bg-primary/15 text-primary flex items-center justify-center text-xs font-semibold hover:bg-primary/25 transition-colors ml-1">
+                  {mounted ? (currentUser?.display_name.charAt(0) ?? '?') : '?'}
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-44">
+                <DropdownMenuLabel className="text-xs font-normal text-muted-foreground truncate">
+                  {mounted ? (currentUser?.display_name ?? '') : ''}
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
+                  <Link href="/settings" className="flex items-center gap-2 cursor-pointer">
+                    <Settings className="w-3.5 h-3.5" />
+                    設定
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive gap-2"
+                  onClick={handleLogout}
                 >
-                  <Mail className="w-5 h-5" />
-                </Link>
-              </div>
+                  <LogOut className="w-3.5 h-3.5" />
+                  ログアウト
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
 
-              {/* User Avatar Dropdown */}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button className="w-8 h-8 rounded-full bg-primary flex items-center justify-center text-primary-foreground text-sm font-bold hover:opacity-80 transition-opacity">
-                    {mounted ? (currentUser?.display_name.charAt(0) ?? '?') : '?'}
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuLabel>{mounted ? (currentUser?.display_name ?? '') : ''}</DropdownMenuLabel>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem asChild>
-                    <Link href="/settings" className="w-full flex items-center">
-                      <Settings className="w-4 h-4 mr-2" />
-                      設定
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    className="text-red-600"
-                    onClick={handleLogout}
-                  >
-                    <LogOut className="w-4 h-4 mr-2" />
-                    ログアウト
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-
-              {/* Mobile Menu Button */}
-              <button
-                className="md:hidden p-2 hover:bg-accent rounded-lg transition-colors"
-                onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-              >
-                {isMobileMenuOpen ? (
-                  <X className="w-5 h-5" />
-                ) : (
-                  <Menu className="w-5 h-5" />
-                )}
-              </button>
-            </div>
+            {/* Mobile hamburger */}
+            <button
+              className="md:hidden p-2 rounded-lg hover:bg-accent transition-colors ml-1"
+              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+            >
+              {isMobileMenuOpen ? <X className="w-4 h-4" /> : <Menu className="w-4 h-4" />}
+            </button>
           </div>
         </div>
 
-        {/* Mobile Navigation Menu */}
+        {/* Mobile menu */}
         {isMobileMenuOpen && (
-          <div className="md:hidden border-t bg-background">
-            <nav className="container mx-auto px-4 py-2">
-              <ul className="flex flex-col gap-1">
-                {NAV_ITEMS.map(({ href, label, icon: Icon }) => (
-                  <li key={href}>
-                    <Button
-                      variant="ghost"
-                      asChild
-                      className="w-full justify-start"
-                      onClick={() => setIsMobileMenuOpen(false)}
-                    >
-                      <Link href={href}>
-                        <Icon className="w-4 h-4 mr-2" />
-                        {label}
-                      </Link>
-                    </Button>
-                  </li>
-                ))}
-              </ul>
+          <div className="md:hidden absolute top-14 left-0 right-0 bg-card/95 backdrop-blur-xl border-b border-border/50 shadow-lg">
+            <nav className="max-w-6xl mx-auto px-4 py-3 flex flex-col gap-1">
+              {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+                const active = pathname.startsWith(href)
+                return (
+                  <Link
+                    key={href}
+                    href={href}
+                    className={`flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-sm transition-colors ${
+                      active
+                        ? 'bg-primary/10 text-primary font-medium'
+                        : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+                    }`}
+                    onClick={() => setIsMobileMenuOpen(false)}
+                  >
+                    <Icon className="w-4 h-4" />
+                    {label}
+                  </Link>
+                )
+              })}
             </nav>
           </div>
         )}

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -10,7 +10,7 @@ export function Card({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="card"
       className={cn(
-        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border',
+        'bg-card text-card-foreground flex flex-col rounded-xl border',
         className
       )}
       {...props}
@@ -26,7 +26,7 @@ export function CardHeader({
     <div
       data-slot="card-header"
       className={cn(
-        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 pt-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1 px-5 pt-5 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-5',
         className
       )}
       {...props}
@@ -41,7 +41,7 @@ export function CardTitle({
   return (
     <h4
       data-slot="card-title"
-      className={cn('leading-none', className)}
+      className={cn('leading-none font-semibold', className)}
       {...props}
     />
   )
@@ -54,7 +54,7 @@ export function CardDescription({
   return (
     <p
       data-slot="card-description"
-      className={cn('text-muted-foreground', className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
   )
@@ -83,7 +83,7 @@ export function CardContent({
   return (
     <div
       data-slot="card-content"
-      className={cn('px-6 [&:last-child]:pb-6', className)}
+      className={cn('px-5 pt-4 [&:last-child]:pb-5', className)}
       {...props}
     />
   )
@@ -96,7 +96,7 @@ export function CardFooter({
   return (
     <div
       data-slot="card-footer"
-      className={cn('flex items-center px-6 pb-6 [.border-t]:pt-6', className)}
+      className={cn('flex items-center px-5 pb-5 [.border-t]:pt-5', className)}
       {...props}
     />
   )

--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -6,13 +6,6 @@ import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
 import { useAuth } from '../hooks/useAuth'
 
 export function LoginForm() {
@@ -30,54 +23,58 @@ export function LoginForm() {
   }
 
   return (
-    <Card className="w-full max-w-md">
-      <CardHeader>
-        <CardTitle className="text-2xl text-center">ログイン</CardTitle>
-      </CardHeader>
-      <form onSubmit={handleSubmit}>
-        <CardContent className="space-y-4">
-          {error && (
-            <p className="text-sm text-red-600 bg-red-50 rounded p-2">
-              {error}
-            </p>
-          )}
-          <div className="space-y-1">
-            <Label htmlFor="email">メールアドレス</Label>
-            <Input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="example@email.com"
-              required
-              autoComplete="email"
-            />
+    <div className="w-full max-w-sm">
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold tracking-tight">おかえりなさい</h1>
+        <p className="text-sm text-muted-foreground mt-1">アカウントにログインしてください</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <div className="text-sm text-destructive bg-destructive/8 border border-destructive/20 rounded-xl px-3.5 py-2.5">
+            {error}
           </div>
-          <div className="space-y-1">
-            <Label htmlFor="password">パスワード</Label>
-            <Input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="パスワードを入力"
-              required
-              autoComplete="current-password"
-            />
-          </div>
-        </CardContent>
-        <CardFooter className="flex flex-col gap-3">
-          <Button type="submit" className="w-full" disabled={loading}>
-            {loading ? 'ログイン中...' : 'ログイン'}
-          </Button>
-          <p className="text-sm text-muted-foreground text-center">
-            アカウントをお持ちでない方は{' '}
-            <Link href="/signup" className="underline hover:text-foreground">
-              新規登録
-            </Link>
-          </p>
-        </CardFooter>
+        )}
+
+        <div className="space-y-1.5">
+          <Label htmlFor="email" className="text-sm font-medium">メールアドレス</Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="example@email.com"
+            required
+            autoComplete="email"
+            className="h-11"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="password" className="text-sm font-medium">パスワード</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="パスワードを入力"
+            required
+            autoComplete="current-password"
+            className="h-11"
+          />
+        </div>
+
+        <Button type="submit" className="w-full h-11 mt-2" disabled={loading}>
+          {loading ? 'ログイン中...' : 'ログイン'}
+        </Button>
       </form>
-    </Card>
+
+      <p className="text-sm text-muted-foreground text-center mt-6">
+        アカウントをお持ちでない方は{' '}
+        <Link href="/signup" className="text-primary font-medium hover:underline">
+          新規登録
+        </Link>
+      </p>
+    </div>
   )
 }

--- a/frontend/src/features/auth/components/SignupForm.tsx
+++ b/frontend/src/features/auth/components/SignupForm.tsx
@@ -6,13 +6,6 @@ import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
 import { useAuth } from '../hooks/useAuth'
 
 export function SignupForm() {
@@ -31,67 +24,73 @@ export function SignupForm() {
   }
 
   return (
-    <Card className="w-full max-w-md">
-      <CardHeader>
-        <CardTitle className="text-2xl text-center">新規登録</CardTitle>
-      </CardHeader>
-      <form onSubmit={handleSubmit}>
-        <CardContent className="space-y-4">
-          {error && (
-            <p className="text-sm text-red-600 bg-red-50 rounded p-2">
-              {error}
-            </p>
-          )}
-          <div className="space-y-1">
-            <Label htmlFor="displayName">表示名</Label>
-            <Input
-              id="displayName"
-              type="text"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              placeholder="あなたの名前"
-              required
-              autoComplete="name"
-            />
+    <div className="w-full max-w-sm">
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold tracking-tight">アカウントを作成</h1>
+        <p className="text-sm text-muted-foreground mt-1">行動を始める仲間と出会いましょう</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <div className="text-sm text-destructive bg-destructive/8 border border-destructive/20 rounded-xl px-3.5 py-2.5">
+            {error}
           </div>
-          <div className="space-y-1">
-            <Label htmlFor="email">メールアドレス</Label>
-            <Input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="example@email.com"
-              required
-              autoComplete="email"
-            />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="password">パスワード</Label>
-            <Input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="8文字以上のパスワード"
-              required
-              minLength={8}
-              autoComplete="new-password"
-            />
-          </div>
-        </CardContent>
-        <CardFooter className="flex flex-col gap-3">
-          <Button type="submit" className="w-full" disabled={loading}>
-            {loading ? '登録中...' : 'アカウントを作成'}
-          </Button>
-          <p className="text-sm text-muted-foreground text-center">
-            すでにアカウントをお持ちの方は{' '}
-            <Link href="/login" className="underline hover:text-foreground">
-              ログイン
-            </Link>
-          </p>
-        </CardFooter>
+        )}
+
+        <div className="space-y-1.5">
+          <Label htmlFor="displayName" className="text-sm font-medium">表示名</Label>
+          <Input
+            id="displayName"
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="あなたの名前"
+            required
+            autoComplete="name"
+            className="h-11"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="email" className="text-sm font-medium">メールアドレス</Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="example@email.com"
+            required
+            autoComplete="email"
+            className="h-11"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="password" className="text-sm font-medium">パスワード</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="8文字以上のパスワード"
+            required
+            minLength={8}
+            autoComplete="new-password"
+            className="h-11"
+          />
+        </div>
+
+        <Button type="submit" className="w-full h-11 mt-2" disabled={loading}>
+          {loading ? '登録中...' : 'アカウントを作成'}
+        </Button>
       </form>
-    </Card>
+
+      <p className="text-sm text-muted-foreground text-center mt-6">
+        すでにアカウントをお持ちの方は{' '}
+        <Link href="/login" className="text-primary font-medium hover:underline">
+          ログイン
+        </Link>
+      </p>
+    </div>
   )
 }

--- a/frontend/src/features/buddies/components/BuddyCard.tsx
+++ b/frontend/src/features/buddies/components/BuddyCard.tsx
@@ -20,11 +20,11 @@ export function BuddyCard({ buddy, onOpenChat }: BuddyCardProps) {
 
   return (
     <Card>
-      <CardContent className="pt-6">
-        <div className="flex items-center justify-between mb-4">
+      <CardContent className="pt-4">
+        <div className="flex items-center justify-between mb-3">
           <div>
             <div className="flex items-center gap-2 mb-1">
-              <h3 className="text-xl font-semibold">{buddy.partnerName}</h3>
+              <h3 className="text-base font-semibold">{buddy.partnerName}</h3>
               <Badge variant={buddy.relationType === 'buddy' ? 'default' : 'secondary'}>
                 {buddy.relationType === 'buddy' ? 'バディ' : 'フレンド'}
               </Badge>
@@ -33,7 +33,7 @@ export function BuddyCard({ buddy, onOpenChat }: BuddyCardProps) {
         </div>
 
         {buddy.relationType === 'buddy' && buddy.status === 'active' && (
-          <div className="mb-4">
+          <div className="mb-3">
             <div className="flex items-center justify-between text-sm mb-2">
               <span className="text-muted-foreground">バディ期間の進捗</span>
               <span className="font-medium">残り {daysRemaining}日</span>

--- a/frontend/src/features/calendar/components/CalendarView.tsx
+++ b/frontend/src/features/calendar/components/CalendarView.tsx
@@ -285,7 +285,7 @@ export function CalendarView({
           if (!open) setSelectedItem(null)
         }}
       >
-        <DialogContent>
+        <DialogContent aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>Action Item</DialogTitle>
           </DialogHeader>

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -69,7 +69,7 @@ export function ChatWindow({
   }
 
   return (
-    <Card className="flex flex-col h-[600px]">
+    <Card className="flex flex-col h-[calc(100vh-140px)] md:h-[600px]">
       <CardHeader className="border-b">
         <CardTitle>{participantName}</CardTitle>
       </CardHeader>

--- a/frontend/src/features/home/components/HomeMain.tsx
+++ b/frontend/src/features/home/components/HomeMain.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Users, Calendar, Target, TrendingUp, ChevronRight, Zap } from 'lucide-react'
+import { Users, Calendar, Target, TrendingUp, ChevronRight, Zap, CheckCircle2, Clock } from 'lucide-react'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import Link from 'next/link'
@@ -25,11 +25,63 @@ interface TodayStats {
   completed: number
 }
 
+interface BuddyInfo {
+  partnerId: string
+  partnerName: string
+}
+
+interface BuddyTodayTask {
+  title: string
+  startTime: Date
+  endTime: Date
+}
+
+interface BuddyTodayStatus {
+  tasks: BuddyTodayTask[]
+}
+
+function isTodayTask(startTime: string): boolean {
+  const t = new Date(startTime)
+  const now = new Date()
+  return (
+    t.getFullYear() === now.getFullYear() &&
+    t.getMonth() === now.getMonth() &&
+    t.getDate() === now.getDate()
+  )
+}
+
+function formatTime(d: Date): string {
+  return d.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit', hour12: false })
+}
+
+async function fetchBuddyTodayStatus(partnerId: string): Promise<BuddyTodayStatus> {
+  const res = await fetch(
+    `${API_BASE}/api/v1/action-items?target_user_id=${partnerId}`,
+    { credentials: 'include' }
+  )
+  if (!res.ok) return { tasks: [] }
+  const body: { data: Array<{ title: string; kind: string; start_time: string; end_time: string }> } =
+    await res.json()
+  if (!body?.data) return { tasks: [] }
+  const tasks = body.data
+    .filter((i) => i.kind !== 'break' && isTodayTask(i.start_time))
+    .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
+    .slice(0, 2)
+    .map((i) => ({
+      title: i.title,
+      startTime: new Date(i.start_time),
+      endTime: new Date(i.end_time),
+    }))
+  return { tasks }
+}
+
 export default function HomeMain() {
   const { user: currentUser } = useCurrentUser()
   const [capacity, setCapacity] = useState<CapacityData | null>(null)
   const [profile, setProfile] = useState<ProfileData | null>(null)
   const [todayStats, setTodayStats] = useState<TodayStats | null>(null)
+  const [buddies, setBuddies] = useState<BuddyInfo[]>([])
+  const [buddyStatuses, setBuddyStatuses] = useState<Record<string, BuddyTodayStatus>>({})
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -49,25 +101,40 @@ export default function HomeMain() {
       .then((r) => (r.ok ? r.json() : null))
       .then((body: { data: Array<{ status: string; kind: string; start_time: string }> } | null) => {
         if (!body?.data) return
-        const todayStart = new Date()
-        todayStart.setHours(0, 0, 0, 0)
-        const todayEnd = new Date()
-        todayEnd.setHours(23, 59, 59, 999)
-        const tasks = body.data.filter((i) => {
-          if (i.kind === 'break') return false
-          const t = new Date(i.start_time)
-          return t >= todayStart && t <= todayEnd
-        })
+        const tasks = body.data.filter((i) => i.kind !== 'break' && isTodayTask(i.start_time))
         const done = tasks.filter(
           (i) => i.status === 'completed' || i.status === 'progress_70'
         ).length
         setTodayStats({ total: tasks.length, completed: done })
       })
       .catch(() => null)
+
+    fetch(`${API_BASE}/api/buddy/relationships`, { credentials: 'include' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then(
+        (
+          data: Array<{ partner: { id: string; display_name: string }; status: string }> | null
+        ) => {
+          if (!data) return
+          const active = data
+            .filter((r) => r.status === 'active')
+            .map((r) => ({ partnerId: r.partner.id, partnerName: r.partner.display_name }))
+          setBuddies(active)
+          active.forEach(({ partnerId }) => {
+            fetchBuddyTodayStatus(partnerId)
+              .then((status) =>
+                setBuddyStatuses((prev) => ({ ...prev, [partnerId]: status }))
+              )
+              .catch(() => null)
+          })
+        }
+      )
+      .catch(() => null)
   }, [])
 
   const achievementRate = capacity ? Math.round(capacity.achievement_rate * 100) : null
   const displayName = mounted ? (currentUser?.display_name ?? '') : ''
+  const hasMyTasksToday = todayStats !== null && todayStats.total > 0
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-6">
@@ -80,12 +147,27 @@ export default function HomeMain() {
         </h1>
       </div>
 
+      {/* 今日のタイムブロッキング促しバナー */}
+      {todayStats !== null && !hasMyTasksToday && (
+        <Link href="/calendar">
+          <div className="mb-4 flex items-center gap-3 px-4 py-3 rounded-xl bg-primary/8 border border-primary/20 hover:bg-primary/12 transition-colors cursor-pointer">
+            <div className="p-1.5 bg-primary/15 rounded-lg shrink-0">
+              <Clock className="w-4 h-4 text-primary" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-primary leading-snug">今日のタスクを追加しましょう</p>
+              <p className="text-xs text-primary/70 mt-0.5">タイムブロッキングで一日を計画する</p>
+            </div>
+            <ChevronRight className="w-4 h-4 text-primary/50 shrink-0" />
+          </div>
+        </Link>
+      )}
+
       {/* Bento grid */}
       <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-4">
 
         {/* Hero: 達成率 — spans 2 cols on md */}
         <Card className="md:col-span-2 relative overflow-hidden bg-primary text-primary-foreground border-0 shadow-none">
-          {/* Decorative circles */}
           <div className="absolute -top-8 -right-8 w-32 h-32 bg-white/8 rounded-full pointer-events-none" />
           <div className="absolute bottom-2 -left-6 w-20 h-20 bg-white/6 rounded-full pointer-events-none" />
           <div className="relative p-5">
@@ -176,6 +258,67 @@ export default function HomeMain() {
           </div>
         </Card>
       </div>
+
+      {/* バディの今日の状況 */}
+      {buddies.length > 0 && (
+        <div className="mb-4">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+            バディの今日
+          </p>
+          <Card>
+            <div className="divide-y divide-border/60">
+              {buddies.map(({ partnerId, partnerName }) => {
+                const status = buddyStatuses[partnerId]
+                const isLoaded = status !== undefined
+                const tasks = status?.tasks ?? []
+                const isBlocking = tasks.length > 0
+                return (
+                  <div key={partnerId} className="px-4 py-3">
+                    <div className="flex items-center gap-3 mb-2">
+                      <div
+                        className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold shrink-0 ${
+                          isBlocking
+                            ? 'bg-emerald-500/15 text-emerald-700'
+                            : 'bg-muted text-muted-foreground'
+                        }`}
+                      >
+                        {partnerName.charAt(0)}
+                      </div>
+                      <p className="text-sm font-medium flex-1">{partnerName}</p>
+                      {isLoaded && (
+                        isBlocking ? (
+                          <CheckCircle2 className="w-4 h-4 text-emerald-500 shrink-0" />
+                        ) : (
+                          <Clock className="w-4 h-4 text-muted-foreground/40 shrink-0" />
+                        )
+                      )}
+                    </div>
+
+                    {!isLoaded && (
+                      <p className="text-xs text-muted-foreground pl-10">確認中...</p>
+                    )}
+                    {isLoaded && !isBlocking && (
+                      <p className="text-xs text-muted-foreground pl-10">まだ登録していないようです</p>
+                    )}
+                    {isLoaded && isBlocking && (
+                      <div className="pl-10 flex flex-col gap-1">
+                        {tasks.map((task, i) => (
+                          <div key={i} className="flex items-baseline gap-1.5">
+                            <span className="text-xs tabular-nums text-muted-foreground whitespace-nowrap">
+                              {formatTime(task.startTime)}〜{formatTime(task.endTime)}
+                            </span>
+                            <span className="text-xs font-medium truncate">{task.title}</span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </Card>
+        </div>
+      )}
 
       {/* クイックアクション */}
       <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">

--- a/frontend/src/features/home/components/HomeMain.tsx
+++ b/frontend/src/features/home/components/HomeMain.tsx
@@ -192,7 +192,7 @@ export default function HomeMain() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Card className="hover:shadow-md transition-shadow cursor-pointer">
             <Link href="/matching">
-              <CardHeader>
+              <CardHeader className="pb-6">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
                     <Users className="w-8 h-8 text-primary" />
@@ -209,7 +209,7 @@ export default function HomeMain() {
 
           <Card className="hover:shadow-md transition-shadow cursor-pointer">
             <Link href="/calendar">
-              <CardHeader>
+              <CardHeader className="pb-6">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
                     <Calendar className="w-8 h-8 text-primary" />

--- a/frontend/src/features/home/components/HomeMain.tsx
+++ b/frontend/src/features/home/components/HomeMain.tsx
@@ -1,10 +1,9 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Users, Calendar, Target, TrendingUp, ChevronRight } from 'lucide-react'
+import { Users, Calendar, Target, TrendingUp, ChevronRight, Zap } from 'lucide-react'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Progress } from '@/components/ui/progress'
 import Link from 'next/link'
 import { useCurrentUser } from '@/features/auth/hooks/useCurrentUser'
 
@@ -67,51 +66,59 @@ export default function HomeMain() {
       .catch(() => null)
   }, [])
 
-  const achievementRate = capacity
-    ? Math.round(capacity.achievement_rate * 100)
-    : null
-
+  const achievementRate = capacity ? Math.round(capacity.achievement_rate * 100) : null
   const displayName = mounted ? (currentUser?.display_name ?? '') : ''
 
   return (
-    <div className="container mx-auto px-3 sm:px-4 py-5 max-w-2xl">
+    <div className="max-w-2xl mx-auto px-4 py-6">
 
       {/* グリーティング */}
       <div className="mb-5">
         <p className="text-xs text-muted-foreground mb-0.5">おかえりなさい</p>
-        <h1 className="text-xl font-semibold">
+        <h1 className="text-xl font-semibold tracking-tight">
           {displayName ? `${displayName}さん` : 'ダッシュボード'}
         </h1>
       </div>
 
-      {/* ステータスカード */}
-      <div className="grid grid-cols-3 gap-2 sm:gap-2.5 mb-4">
-        <Card>
-          <div className="p-4">
-            <div className="flex items-center gap-1.5 mb-2.5">
-              <div className="p-1.5 bg-primary/12 rounded-lg">
-                <TrendingUp className="w-3.5 h-3.5 text-primary" />
-              </div>
-              <p className="text-xs text-muted-foreground">達成率</p>
+      {/* Bento grid */}
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-4">
+
+        {/* Hero: 達成率 — spans 2 cols on md */}
+        <Card className="md:col-span-2 relative overflow-hidden bg-primary text-primary-foreground border-0 shadow-none">
+          {/* Decorative circles */}
+          <div className="absolute -top-8 -right-8 w-32 h-32 bg-white/8 rounded-full pointer-events-none" />
+          <div className="absolute bottom-2 -left-6 w-20 h-20 bg-white/6 rounded-full pointer-events-none" />
+          <div className="relative p-5">
+            <div className="flex items-center gap-1.5 mb-3">
+              <TrendingUp className="w-3.5 h-3.5 text-primary-foreground/70" />
+              <p className="text-xs text-primary-foreground/70">達成率</p>
             </div>
-            <p className="text-2xl font-semibold tabular-nums tracking-tight">
-              {achievementRate !== null ? `${achievementRate}%` : '—'}
+            <p className="text-5xl font-bold tabular-nums tracking-tight leading-none mb-1">
+              {achievementRate !== null ? achievementRate : '—'}
+              {achievementRate !== null && <span className="text-2xl font-semibold ml-0.5">%</span>}
             </p>
-            {achievementRate !== null && (
-              <Progress value={achievementRate} className="h-1 mt-2.5" />
-            )}
+            <p className="text-xs text-primary-foreground/60 mt-2">
+              {achievementRate !== null
+                ? achievementRate >= 80
+                  ? '素晴らしい進捗です'
+                  : achievementRate >= 50
+                  ? '順調に進んでいます'
+                  : 'もう一頑張り！'
+                : 'データを読み込み中'}
+            </p>
           </div>
         </Card>
 
+        {/* バディ数 */}
         <Card>
           <div className="p-4">
-            <div className="flex items-center gap-1.5 mb-2.5">
-              <div className="p-1.5 bg-sky-500/12 rounded-lg">
+            <div className="flex items-center gap-1.5 mb-3">
+              <div className="p-1.5 bg-sky-500/10 rounded-lg">
                 <Users className="w-3.5 h-3.5 text-sky-600" />
               </div>
               <p className="text-xs text-muted-foreground">バディ</p>
             </div>
-            <p className="text-2xl font-semibold tabular-nums tracking-tight">
+            <p className="text-3xl font-bold tabular-nums tracking-tight">
               {capacity !== null ? capacity.current_count : '—'}
             </p>
             <p className="text-xs text-muted-foreground mt-0.5">
@@ -120,86 +127,100 @@ export default function HomeMain() {
           </div>
         </Card>
 
+        {/* 今日のタスク */}
         <Card>
           <div className="p-4">
-            <div className="flex items-center gap-1.5 mb-2.5">
-              <div className="p-1.5 bg-emerald-500/12 rounded-lg">
+            <div className="flex items-center gap-1.5 mb-3">
+              <div className="p-1.5 bg-emerald-500/10 rounded-lg">
                 <Calendar className="w-3.5 h-3.5 text-emerald-600" />
               </div>
               <p className="text-xs text-muted-foreground">今日</p>
             </div>
-            <p className="text-2xl font-semibold tabular-nums tracking-tight">
+            <p className="text-3xl font-bold tabular-nums tracking-tight">
               {todayStats !== null ? todayStats.completed : '—'}
             </p>
             <p className="text-xs text-muted-foreground mt-0.5">
-              {todayStats !== null ? `/ ${todayStats.total} 件` : '\u00a0'}
+              {todayStats !== null ? `/ ${todayStats.total} 件完了` : '\u00a0'}
             </p>
           </div>
         </Card>
-      </div>
 
-      {/* 目標 */}
-      {profile && profile.goal_types.length > 0 && (
-        <Card className="mb-4">
-          <div className="px-4 py-3.5">
-            <div className="flex items-center justify-between mb-2.5">
+        {/* 目標タグ */}
+        <Card className="col-span-2 md:col-span-1">
+          <div className="p-4">
+            <div className="flex items-center justify-between mb-3">
               <div className="flex items-center gap-1.5">
-                <Target className="w-3.5 h-3.5 text-primary" />
-                <span className="text-xs font-medium text-muted-foreground">設定中の目標</span>
+                <div className="p-1.5 bg-primary/10 rounded-lg">
+                  <Target className="w-3.5 h-3.5 text-primary" />
+                </div>
+                <p className="text-xs text-muted-foreground">目標</p>
               </div>
               <Button variant="ghost" size="sm" asChild className="h-6 text-xs px-2 -mr-1">
                 <Link href="/matching">編集</Link>
               </Button>
             </div>
-            <div className="flex flex-wrap gap-1.5">
-              {profile.goal_types.map((goal) => (
-                <span
-                  key={goal}
-                  className="px-2.5 py-0.5 bg-primary/10 text-primary text-xs rounded-full"
-                >
-                  {goal}
-                </span>
-              ))}
-            </div>
-            {profile.bio && (
-              <p className="mt-2 text-xs text-muted-foreground">{profile.bio}</p>
+            {profile && profile.goal_types.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5">
+                {profile.goal_types.map((goal) => (
+                  <span
+                    key={goal}
+                    className="px-2 py-0.5 bg-primary/10 text-primary text-xs rounded-full"
+                  >
+                    {goal}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">目標が未設定です</p>
             )}
           </div>
         </Card>
-      )}
+      </div>
 
       {/* クイックアクション */}
       <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
         クイックアクション
       </p>
-      <div className="flex flex-col gap-2">
-        <Card className="hover:bg-secondary/50 transition-colors cursor-pointer">
+      <div className="flex flex-col gap-1.5">
+        <Card className="hover:bg-secondary/60 transition-colors cursor-pointer">
           <Link href="/matching" className="flex items-center gap-3 px-4 py-3.5">
-            <div className="p-2 bg-primary/12 rounded-xl shrink-0">
+            <div className="p-2 bg-primary/10 rounded-xl shrink-0">
               <Users className="w-4 h-4 text-primary" />
             </div>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium leading-snug">バディを探す</p>
               <p className="text-xs text-muted-foreground">目標が近い人とマッチング</p>
             </div>
-            <ChevronRight className="w-4 h-4 text-muted-foreground/50 shrink-0" />
+            <ChevronRight className="w-4 h-4 text-muted-foreground/40 shrink-0" />
           </Link>
         </Card>
 
-        <Card className="hover:bg-secondary/50 transition-colors cursor-pointer">
+        <Card className="hover:bg-secondary/60 transition-colors cursor-pointer">
           <Link href="/calendar" className="flex items-center gap-3 px-4 py-3.5">
-            <div className="p-2 bg-emerald-500/12 rounded-xl shrink-0">
+            <div className="p-2 bg-emerald-500/10 rounded-xl shrink-0">
               <Calendar className="w-4 h-4 text-emerald-600" />
             </div>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium leading-snug">カレンダー</p>
               <p className="text-xs text-muted-foreground">Action Itemを管理する</p>
             </div>
-            <ChevronRight className="w-4 h-4 text-muted-foreground/50 shrink-0" />
+            <ChevronRight className="w-4 h-4 text-muted-foreground/40 shrink-0" />
+          </Link>
+        </Card>
+
+        <Card className="hover:bg-secondary/60 transition-colors cursor-pointer">
+          <Link href="/chat" className="flex items-center gap-3 px-4 py-3.5">
+            <div className="p-2 bg-amber-500/10 rounded-xl shrink-0">
+              <Zap className="w-4 h-4 text-amber-600" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium leading-snug">チャット</p>
+              <p className="text-xs text-muted-foreground">バディとメッセージ</p>
+            </div>
+            <ChevronRight className="w-4 h-4 text-muted-foreground/40 shrink-0" />
           </Link>
         </Card>
       </div>
-
     </div>
   )
 }

--- a/frontend/src/features/home/components/HomeMain.tsx
+++ b/frontend/src/features/home/components/HomeMain.tsx
@@ -20,9 +20,10 @@ interface ProfileData {
   bio: string
 }
 
-interface TodayStats {
-  total: number
-  completed: number
+interface UpcomingTask {
+  title: string
+  startTime: Date
+  endTime: Date
 }
 
 interface BuddyInfo {
@@ -38,6 +39,12 @@ interface BuddyTodayTask {
 
 interface BuddyTodayStatus {
   tasks: BuddyTodayTask[]
+}
+
+function todayStart(): Date {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  return d
 }
 
 function isTodayTask(startTime: string): boolean {
@@ -66,7 +73,7 @@ async function fetchBuddyTodayStatus(partnerId: string): Promise<BuddyTodayStatu
   const tasks = body.data
     .filter((i) => i.kind !== 'break' && isTodayTask(i.start_time))
     .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
-    .slice(0, 2)
+    .slice(0, 4)
     .map((i) => ({
       title: i.title,
       startTime: new Date(i.start_time),
@@ -79,7 +86,8 @@ export default function HomeMain() {
   const { user: currentUser } = useCurrentUser()
   const [capacity, setCapacity] = useState<CapacityData | null>(null)
   const [profile, setProfile] = useState<ProfileData | null>(null)
-  const [todayStats, setTodayStats] = useState<TodayStats | null>(null)
+  const [upcomingTasks, setUpcomingTasks] = useState<UpcomingTask[] | null>(null)
+  const [hasTodayTask, setHasTodayTask] = useState<boolean | null>(null)
   const [buddies, setBuddies] = useState<BuddyInfo[]>([])
   const [buddyStatuses, setBuddyStatuses] = useState<Record<string, BuddyTodayStatus>>({})
   const [mounted, setMounted] = useState(false)
@@ -99,22 +107,37 @@ export default function HomeMain() {
 
     fetch(`${API_BASE}/api/v1/action-items`, { credentials: 'include' })
       .then((r) => (r.ok ? r.json() : null))
-      .then((body: { data: Array<{ status: string; kind: string; start_time: string }> } | null) => {
-        if (!body?.data) return
-        const tasks = body.data.filter((i) => i.kind !== 'break' && isTodayTask(i.start_time))
-        const done = tasks.filter(
-          (i) => i.status === 'completed' || i.status === 'progress_70'
-        ).length
-        setTodayStats({ total: tasks.length, completed: done })
-      })
+      .then(
+        (body: {
+          data: Array<{ title: string; status: string; kind: string; start_time: string; end_time: string }>
+        } | null) => {
+          if (!body?.data) return
+          const threshold = todayStart()
+          setHasTodayTask(body.data.some((i) => i.kind !== 'break' && isTodayTask(i.start_time)))
+          const upcoming = body.data
+            .filter(
+              (i) =>
+                i.kind !== 'break' &&
+                new Date(i.start_time) >= threshold &&
+                i.status !== 'completed' &&
+                i.status !== 'progress_70'
+            )
+            .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
+            .slice(0, 4)
+            .map((i) => ({
+              title: i.title,
+              startTime: new Date(i.start_time),
+              endTime: new Date(i.end_time),
+            }))
+          setUpcomingTasks(upcoming)
+        }
+      )
       .catch(() => null)
 
     fetch(`${API_BASE}/api/buddy/relationships`, { credentials: 'include' })
       .then((r) => (r.ok ? r.json() : null))
       .then(
-        (
-          data: Array<{ partner: { id: string; display_name: string }; status: string }> | null
-        ) => {
+        (data: Array<{ partner: { id: string; display_name: string }; status: string }> | null) => {
           if (!data) return
           const active = data
             .filter((r) => r.status === 'active')
@@ -134,7 +157,6 @@ export default function HomeMain() {
 
   const achievementRate = capacity ? Math.round(capacity.achievement_rate * 100) : null
   const displayName = mounted ? (currentUser?.display_name ?? '') : ''
-  const hasMyTasksToday = todayStats !== null && todayStats.total > 0
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-6">
@@ -148,7 +170,7 @@ export default function HomeMain() {
       </div>
 
       {/* 今日のタイムブロッキング促しバナー */}
-      {todayStats !== null && !hasMyTasksToday && (
+      {hasTodayTask === false && (
         <Link href="/calendar">
           <div className="mb-4 flex items-center gap-3 px-4 py-3 rounded-xl bg-primary/8 border border-primary/20 hover:bg-primary/12 transition-colors cursor-pointer">
             <div className="p-1.5 bg-primary/15 rounded-lg shrink-0">
@@ -166,8 +188,8 @@ export default function HomeMain() {
       {/* Bento grid */}
       <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-4">
 
-        {/* Hero: 達成率 — spans 2 cols on md */}
-        <Card className="md:col-span-2 relative overflow-hidden bg-primary text-primary-foreground border-0 shadow-none">
+        {/* Hero: 達成率 */}
+        <Card className="col-span-2 md:col-span-2 relative overflow-hidden bg-primary text-primary-foreground border-0 shadow-none">
           <div className="absolute -top-8 -right-8 w-32 h-32 bg-white/8 rounded-full pointer-events-none" />
           <div className="absolute bottom-2 -left-6 w-20 h-20 bg-white/6 rounded-full pointer-events-none" />
           <div className="relative p-5">
@@ -187,42 +209,6 @@ export default function HomeMain() {
                   ? '順調に進んでいます'
                   : 'もう一頑張り！'
                 : 'データを読み込み中'}
-            </p>
-          </div>
-        </Card>
-
-        {/* バディ数 */}
-        <Card>
-          <div className="p-4">
-            <div className="flex items-center gap-1.5 mb-3">
-              <div className="p-1.5 bg-sky-500/10 rounded-lg">
-                <Users className="w-3.5 h-3.5 text-sky-600" />
-              </div>
-              <p className="text-xs text-muted-foreground">バディ</p>
-            </div>
-            <p className="text-3xl font-bold tabular-nums tracking-tight">
-              {capacity !== null ? capacity.current_count : '—'}
-            </p>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {capacity !== null ? `/ ${capacity.max_count} 人` : '\u00a0'}
-            </p>
-          </div>
-        </Card>
-
-        {/* 今日のタスク */}
-        <Card>
-          <div className="p-4">
-            <div className="flex items-center gap-1.5 mb-3">
-              <div className="p-1.5 bg-emerald-500/10 rounded-lg">
-                <Calendar className="w-3.5 h-3.5 text-emerald-600" />
-              </div>
-              <p className="text-xs text-muted-foreground">今日</p>
-            </div>
-            <p className="text-3xl font-bold tabular-nums tracking-tight">
-              {todayStats !== null ? todayStats.completed : '—'}
-            </p>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {todayStats !== null ? `/ ${todayStats.total} 件完了` : '\u00a0'}
             </p>
           </div>
         </Card>
@@ -254,6 +240,36 @@ export default function HomeMain() {
               </div>
             ) : (
               <p className="text-xs text-muted-foreground">目標が未設定です</p>
+            )}
+          </div>
+        </Card>
+
+        {/* 直近の未完了タスク */}
+        <Card className="col-span-2 md:col-span-3">
+          <div className="px-4 py-3.5">
+            <div className="flex items-center gap-1.5 mb-3">
+              <div className="p-1.5 bg-emerald-500/10 rounded-lg">
+                <Calendar className="w-3.5 h-3.5 text-emerald-600" />
+              </div>
+              <p className="text-xs text-muted-foreground">直近のタスク</p>
+            </div>
+            {upcomingTasks === null && (
+              <p className="text-xs text-muted-foreground">読み込み中...</p>
+            )}
+            {upcomingTasks !== null && upcomingTasks.length === 0 && (
+              <p className="text-xs text-muted-foreground">未完了のタスクはありません</p>
+            )}
+            {upcomingTasks !== null && upcomingTasks.length > 0 && (
+              <div className="flex flex-col gap-2">
+                {upcomingTasks.map((task, i) => (
+                  <div key={i} className="flex items-center gap-3">
+                    <span className="text-xs tabular-nums text-muted-foreground whitespace-nowrap w-28 shrink-0">
+                      {formatTime(task.startTime)}〜{formatTime(task.endTime)}
+                    </span>
+                    <span className="text-sm truncate">{task.title}</span>
+                  </div>
+                ))}
+              </div>
             )}
           </div>
         </Card>
@@ -301,13 +317,13 @@ export default function HomeMain() {
                       <p className="text-xs text-muted-foreground pl-10">まだ登録していないようです</p>
                     )}
                     {isLoaded && isBlocking && (
-                      <div className="pl-10 flex flex-col gap-1">
+                      <div className="pl-10 flex flex-col gap-1.5">
                         {tasks.map((task, i) => (
-                          <div key={i} className="flex items-baseline gap-1.5">
-                            <span className="text-xs tabular-nums text-muted-foreground whitespace-nowrap">
+                          <div key={i} className="flex items-center gap-3">
+                            <span className="text-xs tabular-nums text-muted-foreground whitespace-nowrap w-28 shrink-0">
                               {formatTime(task.startTime)}〜{formatTime(task.endTime)}
                             </span>
-                            <span className="text-xs font-medium truncate">{task.title}</span>
+                            <span className="text-xs truncate">{task.title}</span>
                           </div>
                         ))}
                       </div>

--- a/frontend/src/features/home/components/HomeMain.tsx
+++ b/frontend/src/features/home/components/HomeMain.tsx
@@ -1,14 +1,8 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Users, Calendar, Target, TrendingUp, ArrowRight } from 'lucide-react'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
+import { Users, Calendar, Target, TrendingUp, ChevronRight } from 'lucide-react'
+import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Progress } from '@/components/ui/progress'
 import Link from 'next/link'
@@ -80,151 +74,132 @@ export default function HomeMain() {
   const displayName = mounted ? (currentUser?.display_name ?? '') : ''
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="max-w-4xl mx-auto">
-        {/* グリーティング */}
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold mb-1">
-            {displayName ? `こんにちは、${displayName}さん` : 'ダッシュボード'}
-          </h1>
-          <p className="text-muted-foreground">今日も一緒に目標に向かって進みましょう</p>
-        </div>
+    <div className="container mx-auto px-4 py-6 max-w-2xl">
 
-        {/* ステータスカード */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-          {/* 達成率 */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-3 mb-3">
-                <div className="p-2 bg-primary/15 rounded-xl">
-                  <TrendingUp className="w-5 h-5 text-primary" />
-                </div>
-                <p className="text-sm text-muted-foreground">直近7日の達成率</p>
-              </div>
-              <p className="text-3xl font-bold mb-2">
-                {achievementRate !== null ? `${achievementRate}%` : '—'}
-              </p>
-              {achievementRate !== null && (
-                <Progress value={achievementRate} className="h-2" />
-              )}
-            </CardContent>
-          </Card>
-
-          {/* バディ枠 */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-3 mb-3">
-                <div className="p-2 bg-sky-500/15 rounded-xl">
-                  <Users className="w-5 h-5 text-sky-600" />
-                </div>
-                <p className="text-sm text-muted-foreground">バディ</p>
-              </div>
-              <p className="text-3xl font-bold mb-1">
-                {capacity !== null
-                  ? `${capacity.current_count} / ${capacity.max_count}`
-                  : '—'}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {capacity !== null ? `上限 ${capacity.max_count}人` : '読み込み中...'}
-              </p>
-            </CardContent>
-          </Card>
-
-          {/* 今日のAction Item */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-3 mb-3">
-                <div className="p-2 bg-emerald-500/15 rounded-xl">
-                  <Calendar className="w-5 h-5 text-emerald-600" />
-                </div>
-                <p className="text-sm text-muted-foreground">今日のタスク</p>
-              </div>
-              <p className="text-3xl font-bold mb-1">
-                {todayStats !== null
-                  ? `${todayStats.completed} / ${todayStats.total}`
-                  : '—'}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {todayStats !== null
-                  ? `${todayStats.total}件中${todayStats.completed}件完了`
-                  : '読み込み中...'}
-              </p>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* 目標 */}
-        {profile && profile.goal_types.length > 0 && (
-          <Card className="mb-8">
-            <CardHeader className="pb-3">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Target className="w-5 h-5 text-primary" />
-                  <CardTitle className="text-base">設定中の目標</CardTitle>
-                </div>
-                <Button variant="ghost" size="sm" asChild>
-                  <Link href="/matching" className="flex items-center gap-1 text-xs">
-                    プロフィールを編集
-                    <ArrowRight className="w-3 h-3" />
-                  </Link>
-                </Button>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="flex flex-wrap gap-2">
-                {profile.goal_types.map((goal) => (
-                  <span
-                    key={goal}
-                    className="px-3 py-1 bg-primary/10 text-primary text-sm rounded-full"
-                  >
-                    {goal}
-                  </span>
-                ))}
-              </div>
-              {profile.bio && (
-                <p className="mt-3 text-sm text-muted-foreground">{profile.bio}</p>
-              )}
-            </CardContent>
-          </Card>
-        )}
-
-        {/* クイックアクション */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <Card className="hover:shadow-md transition-shadow cursor-pointer">
-            <Link href="/matching">
-              <CardHeader className="pb-6">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <Users className="w-7 h-7 text-primary" />
-                    <div>
-                      <CardTitle className="text-base">バディを探す</CardTitle>
-                      <CardDescription>目標が近い人とマッチング</CardDescription>
-                    </div>
-                  </div>
-                  <ArrowRight className="w-4 h-4 text-muted-foreground" />
-                </div>
-              </CardHeader>
-            </Link>
-          </Card>
-
-          <Card className="hover:shadow-md transition-shadow cursor-pointer">
-            <Link href="/calendar">
-              <CardHeader className="pb-6">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <Calendar className="w-7 h-7 text-primary" />
-                    <div>
-                      <CardTitle className="text-base">カレンダー</CardTitle>
-                      <CardDescription>Action Itemを管理する</CardDescription>
-                    </div>
-                  </div>
-                  <ArrowRight className="w-4 h-4 text-muted-foreground" />
-                </div>
-              </CardHeader>
-            </Link>
-          </Card>
-        </div>
+      {/* グリーティング */}
+      <div className="mb-5">
+        <p className="text-xs text-muted-foreground mb-0.5">おかえりなさい</p>
+        <h1 className="text-xl font-semibold">
+          {displayName ? `${displayName}さん` : 'ダッシュボード'}
+        </h1>
       </div>
+
+      {/* ステータスカード */}
+      <div className="grid grid-cols-3 gap-2.5 mb-4">
+        <Card>
+          <div className="p-4">
+            <div className="flex items-center gap-1.5 mb-2.5">
+              <div className="p-1.5 bg-primary/12 rounded-lg">
+                <TrendingUp className="w-3.5 h-3.5 text-primary" />
+              </div>
+              <p className="text-xs text-muted-foreground">達成率</p>
+            </div>
+            <p className="text-2xl font-semibold tabular-nums tracking-tight">
+              {achievementRate !== null ? `${achievementRate}%` : '—'}
+            </p>
+            {achievementRate !== null && (
+              <Progress value={achievementRate} className="h-1 mt-2.5" />
+            )}
+          </div>
+        </Card>
+
+        <Card>
+          <div className="p-4">
+            <div className="flex items-center gap-1.5 mb-2.5">
+              <div className="p-1.5 bg-sky-500/12 rounded-lg">
+                <Users className="w-3.5 h-3.5 text-sky-600" />
+              </div>
+              <p className="text-xs text-muted-foreground">バディ</p>
+            </div>
+            <p className="text-2xl font-semibold tabular-nums tracking-tight">
+              {capacity !== null ? capacity.current_count : '—'}
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {capacity !== null ? `/ ${capacity.max_count} 人` : '\u00a0'}
+            </p>
+          </div>
+        </Card>
+
+        <Card>
+          <div className="p-4">
+            <div className="flex items-center gap-1.5 mb-2.5">
+              <div className="p-1.5 bg-emerald-500/12 rounded-lg">
+                <Calendar className="w-3.5 h-3.5 text-emerald-600" />
+              </div>
+              <p className="text-xs text-muted-foreground">今日</p>
+            </div>
+            <p className="text-2xl font-semibold tabular-nums tracking-tight">
+              {todayStats !== null ? todayStats.completed : '—'}
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {todayStats !== null ? `/ ${todayStats.total} 件` : '\u00a0'}
+            </p>
+          </div>
+        </Card>
+      </div>
+
+      {/* 目標 */}
+      {profile && profile.goal_types.length > 0 && (
+        <Card className="mb-4">
+          <div className="px-4 py-3.5">
+            <div className="flex items-center justify-between mb-2.5">
+              <div className="flex items-center gap-1.5">
+                <Target className="w-3.5 h-3.5 text-primary" />
+                <span className="text-xs font-medium text-muted-foreground">設定中の目標</span>
+              </div>
+              <Button variant="ghost" size="sm" asChild className="h-6 text-xs px-2 -mr-1">
+                <Link href="/matching">編集</Link>
+              </Button>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {profile.goal_types.map((goal) => (
+                <span
+                  key={goal}
+                  className="px-2.5 py-0.5 bg-primary/10 text-primary text-xs rounded-full"
+                >
+                  {goal}
+                </span>
+              ))}
+            </div>
+            {profile.bio && (
+              <p className="mt-2 text-xs text-muted-foreground">{profile.bio}</p>
+            )}
+          </div>
+        </Card>
+      )}
+
+      {/* クイックアクション */}
+      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+        クイックアクション
+      </p>
+      <div className="flex flex-col gap-2">
+        <Card className="hover:bg-secondary/50 transition-colors cursor-pointer">
+          <Link href="/matching" className="flex items-center gap-3 px-4 py-3.5">
+            <div className="p-2 bg-primary/12 rounded-xl shrink-0">
+              <Users className="w-4 h-4 text-primary" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium leading-snug">バディを探す</p>
+              <p className="text-xs text-muted-foreground">目標が近い人とマッチング</p>
+            </div>
+            <ChevronRight className="w-4 h-4 text-muted-foreground/50 shrink-0" />
+          </Link>
+        </Card>
+
+        <Card className="hover:bg-secondary/50 transition-colors cursor-pointer">
+          <Link href="/calendar" className="flex items-center gap-3 px-4 py-3.5">
+            <div className="p-2 bg-emerald-500/12 rounded-xl shrink-0">
+              <Calendar className="w-4 h-4 text-emerald-600" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium leading-snug">カレンダー</p>
+              <p className="text-xs text-muted-foreground">Action Itemを管理する</p>
+            </div>
+            <ChevronRight className="w-4 h-4 text-muted-foreground/50 shrink-0" />
+          </Link>
+        </Card>
+      </div>
+
     </div>
   )
 }

--- a/frontend/src/features/home/components/HomeMain.tsx
+++ b/frontend/src/features/home/components/HomeMain.tsx
@@ -74,7 +74,7 @@ export default function HomeMain() {
   const displayName = mounted ? (currentUser?.display_name ?? '') : ''
 
   return (
-    <div className="container mx-auto px-4 py-6 max-w-2xl">
+    <div className="container mx-auto px-3 sm:px-4 py-5 max-w-2xl">
 
       {/* グリーティング */}
       <div className="mb-5">
@@ -85,7 +85,7 @@ export default function HomeMain() {
       </div>
 
       {/* ステータスカード */}
-      <div className="grid grid-cols-3 gap-2.5 mb-4">
+      <div className="grid grid-cols-3 gap-2 sm:gap-2.5 mb-4">
         <Card>
           <div className="p-4">
             <div className="flex items-center gap-1.5 mb-2.5">

--- a/frontend/src/features/home/components/HomeMain.tsx
+++ b/frontend/src/features/home/components/HomeMain.tsx
@@ -96,7 +96,7 @@ export default function HomeMain() {
           <Card>
             <CardContent className="pt-6">
               <div className="flex items-center gap-3 mb-3">
-                <div className="p-2 bg-primary/10 rounded-lg">
+                <div className="p-2 bg-primary/15 rounded-xl">
                   <TrendingUp className="w-5 h-5 text-primary" />
                 </div>
                 <p className="text-sm text-muted-foreground">直近7日の達成率</p>
@@ -114,8 +114,8 @@ export default function HomeMain() {
           <Card>
             <CardContent className="pt-6">
               <div className="flex items-center gap-3 mb-3">
-                <div className="p-2 bg-blue-500/10 rounded-lg">
-                  <Users className="w-5 h-5 text-blue-500" />
+                <div className="p-2 bg-sky-500/15 rounded-xl">
+                  <Users className="w-5 h-5 text-sky-600" />
                 </div>
                 <p className="text-sm text-muted-foreground">バディ</p>
               </div>
@@ -134,8 +134,8 @@ export default function HomeMain() {
           <Card>
             <CardContent className="pt-6">
               <div className="flex items-center gap-3 mb-3">
-                <div className="p-2 bg-green-500/10 rounded-lg">
-                  <Calendar className="w-5 h-5 text-green-500" />
+                <div className="p-2 bg-emerald-500/15 rounded-xl">
+                  <Calendar className="w-5 h-5 text-emerald-600" />
                 </div>
                 <p className="text-sm text-muted-foreground">今日のタスク</p>
               </div>
@@ -195,7 +195,7 @@ export default function HomeMain() {
               <CardHeader className="pb-6">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
-                    <Users className="w-8 h-8 text-primary" />
+                    <Users className="w-7 h-7 text-primary" />
                     <div>
                       <CardTitle className="text-base">バディを探す</CardTitle>
                       <CardDescription>目標が近い人とマッチング</CardDescription>
@@ -212,7 +212,7 @@ export default function HomeMain() {
               <CardHeader className="pb-6">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
-                    <Calendar className="w-8 h-8 text-primary" />
+                    <Calendar className="w-7 h-7 text-primary" />
                     <div>
                       <CardTitle className="text-base">カレンダー</CardTitle>
                       <CardDescription>Action Itemを管理する</CardDescription>

--- a/frontend/src/features/matching/components/MatchingMain.tsx
+++ b/frontend/src/features/matching/components/MatchingMain.tsx
@@ -3,9 +3,9 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { Users, Clock, CheckCircle, UserX } from 'lucide-react'
+import { Users, Clock, MessageSquare, UserX } from 'lucide-react'
 import { useMatching } from '../hooks/useMatching'
 import { useBuddyProfile } from '../hooks/useBuddyProfile'
 import { BuddyProfileForm } from './BuddyProfileForm'
@@ -50,7 +50,7 @@ export default function MatchingMain() {
 
   if (loading) {
     return (
-      <div className="container mx-auto px-4 py-8 text-center text-muted-foreground">
+      <div className="container mx-auto px-4 py-8 text-center text-muted-foreground text-sm">
         読み込み中...
       </div>
     )
@@ -59,69 +59,70 @@ export default function MatchingMain() {
   const inQueue = queueStatus?.in_queue && queueStatus.status === 'waiting'
 
   return (
-    <div className="container mx-auto px-4 py-8 space-y-8">
-      <div className="text-center">
-        <h1 className="text-3xl font-bold mb-2">バディを探す</h1>
-        <p className="text-muted-foreground">目標や活動時間が近い人と自動でマッチングします</p>
+    <div className="container mx-auto px-4 py-6 max-w-xl space-y-5">
+
+      <div>
+        <h1 className="text-xl font-semibold">バディを探す</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">目標や活動時間が近い人と自動でマッチングします</p>
       </div>
 
       {actionError && (
-        <div className="max-w-2xl mx-auto bg-destructive/10 text-destructive rounded-md px-4 py-3 text-sm">
+        <div className="bg-destructive/10 text-destructive rounded-lg px-4 py-3 text-sm">
           {actionError}
         </div>
       )}
 
       {/* バディ上限 */}
       {capacity && (
-        <Card className="max-w-2xl mx-auto">
-          <CardContent className="flex items-center justify-between py-4">
+        <Card>
+          <div className="flex items-center justify-between px-4 py-3.5">
             <div className="flex items-center gap-2">
-              <Users className="w-5 h-5 text-primary" />
-              <span className="font-medium">現在のバディ数</span>
+              <Users className="w-4 h-4 text-primary" />
+              <span className="text-sm font-medium">現在のバディ数</span>
             </div>
             <div className="text-right">
-              <span className="text-2xl font-bold">{capacity.current_count}</span>
-              <span className="text-muted-foreground"> / {capacity.max_count} 人</span>
+              <span className="text-lg font-semibold tabular-nums">{capacity.current_count}</span>
+              <span className="text-muted-foreground text-sm"> / {capacity.max_count} 人</span>
               <p className="text-xs text-muted-foreground">
                 達成率 {Math.round(capacity.achievement_rate * 100)}%
               </p>
             </div>
-          </CardContent>
+          </div>
         </Card>
       )}
 
       {/* プロフィール設定 */}
-      <div className="max-w-2xl mx-auto">
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-lg font-semibold">プロフィール</h2>
-          <Button variant="outline" size="sm" onClick={() => setShowProfileForm((v) => !v)}>
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">プロフィール</p>
+          <Button variant="ghost" size="sm" className="h-6 text-xs px-2" onClick={() => setShowProfileForm((v) => !v)}>
             {showProfileForm ? '閉じる' : profile ? '編集' : '設定する'}
           </Button>
         </div>
 
         {!profile && !showProfileForm && (
           <Card>
-            <CardContent className="py-6 text-center text-muted-foreground text-sm">
+            <div className="px-4 py-4 text-center text-sm text-muted-foreground">
               マッチングに参加するにはプロフィールを設定してください
-            </CardContent>
+            </div>
           </Card>
         )}
 
         {profile && !showProfileForm && (
           <Card>
-            <CardContent className="py-4 space-y-3">
+            <div className="px-4 py-3.5 space-y-2.5">
               {profile.bio && <p className="text-sm">{profile.bio}</p>}
               <div className="flex flex-wrap gap-1">
                 {profile.goal_types.map((g) => (
-                  <Badge key={g} variant="default">{g}</Badge>
+                  <Badge key={g} variant="default" className="text-xs">{g}</Badge>
                 ))}
               </div>
               <div className="flex flex-wrap gap-1">
                 {profile.active_times.map((t) => (
-                  <Badge key={t} variant="secondary">{t}</Badge>
+                  <Badge key={t} variant="secondary" className="text-xs">{t}</Badge>
                 ))}
               </div>
-            </CardContent>
+            </div>
           </Card>
         )}
 
@@ -138,90 +139,91 @@ export default function MatchingMain() {
 
       {/* キュー操作 */}
       {profile && (
-        <div className="max-w-2xl mx-auto">
-          <Card>
-            <CardContent className="flex flex-col items-center py-8 space-y-4">
-              {inQueue ? (
-                <>
-                  <div className="flex items-center gap-2 text-primary">
-                    <Clock className="w-6 h-6 animate-pulse" />
-                    <span className="font-semibold text-lg">マッチング待機中</span>
-                  </div>
-                  <p className="text-sm text-muted-foreground text-center">
-                    バディが見つかると通知でお知らせします
-                    {queueStatus?.expires_at && (
-                      <span className="block">
-                        有効期限: {new Date(queueStatus.expires_at).toLocaleDateString('ja-JP')}
-                      </span>
-                    )}
-                  </p>
-                  <Button variant="outline" onClick={handleLeaveQueue}>
-                    キャンセル
-                  </Button>
-                </>
-              ) : (
-                <>
-                  <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center">
-                    <Users className="w-8 h-8 text-primary" />
-                  </div>
-                  <p className="text-sm text-muted-foreground text-center max-w-xs">
-                    マッチングキューに参加すると、1時間ごとに自動でバディを探します
-                  </p>
-                  <Button
-                    onClick={handleJoinQueue}
-                    disabled={!capacity || capacity.current_count >= capacity.max_count}
-                  >
-                    マッチングに参加する
-                  </Button>
-                  {capacity && capacity.current_count >= capacity.max_count && (
-                    <p className="text-xs text-muted-foreground">バディの上限数に達しています</p>
+        <Card>
+          <div className="flex flex-col items-center px-4 py-6 gap-3">
+            {inQueue ? (
+              <>
+                <div className="flex items-center gap-2 text-primary">
+                  <Clock className="w-5 h-5 animate-pulse" />
+                  <span className="font-medium">マッチング待機中</span>
+                </div>
+                <p className="text-xs text-muted-foreground text-center">
+                  バディが見つかると通知でお知らせします
+                  {queueStatus?.expires_at && (
+                    <span className="block mt-0.5">
+                      有効期限: {new Date(queueStatus.expires_at).toLocaleDateString('ja-JP')}
+                    </span>
                   )}
-                </>
-              )}
-            </CardContent>
-          </Card>
-        </div>
+                </p>
+                <Button variant="outline" size="sm" onClick={handleLeaveQueue}>
+                  キャンセル
+                </Button>
+              </>
+            ) : (
+              <>
+                <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-primary" />
+                </div>
+                <p className="text-xs text-muted-foreground text-center max-w-xs">
+                  マッチングキューに参加すると、1時間ごとに自動でバディを探します
+                </p>
+                <Button
+                  onClick={handleJoinQueue}
+                  disabled={!capacity || capacity.current_count >= capacity.max_count}
+                >
+                  マッチングに参加する
+                </Button>
+                {capacity && capacity.current_count >= capacity.max_count && (
+                  <p className="text-xs text-muted-foreground">バディの上限数に達しています</p>
+                )}
+              </>
+            )}
+          </div>
+        </Card>
       )}
 
       {/* アクティブなバディ一覧 */}
       {relationships.length > 0 && (
-        <div className="max-w-2xl mx-auto space-y-3">
-          <h2 className="text-lg font-semibold">現在のバディ</h2>
-          {relationships.map((rel) => (
-            <Card key={rel.id}>
-              <CardContent className="flex items-center justify-between py-4">
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center font-semibold text-primary">
-                    {rel.partner.display_name.charAt(0)}
+        <div>
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">現在のバディ</p>
+          <div className="flex flex-col gap-2">
+            {relationships.map((rel) => (
+              <Card key={rel.id}>
+                <div className="flex items-center justify-between px-4 py-3.5">
+                  <div className="flex items-center gap-3">
+                    <div className="w-9 h-9 rounded-full bg-primary/10 flex items-center justify-center font-semibold text-primary text-sm">
+                      {rel.partner.display_name.charAt(0)}
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium">{rel.partner.display_name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {new Date(rel.ends_at).toLocaleDateString('ja-JP')} まで
+                      </p>
+                    </div>
                   </div>
-                  <div>
-                    <p className="font-medium">{rel.partner.display_name}</p>
-                    <p className="text-xs text-muted-foreground">
-                      終了: {new Date(rel.ends_at).toLocaleDateString('ja-JP')}
-                    </p>
+                  <div className="flex gap-1.5">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-8 text-xs"
+                      onClick={() => router.push(`/chat?room=${rel.room_id}`)}
+                    >
+                      <MessageSquare className="w-3.5 h-3.5 mr-1" />
+                      チャット
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                      onClick={() => handleEndRelationship(rel.id)}
+                    >
+                      <UserX className="w-3.5 h-3.5" />
+                    </Button>
                   </div>
                 </div>
-                <div className="flex gap-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => router.push(`/chat?room=${rel.room_id}`)}
-                  >
-                    <CheckCircle className="w-4 h-4 mr-1" />
-                    チャット
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="text-destructive hover:text-destructive"
-                    onClick={() => handleEndRelationship(rel.id)}
-                  >
-                    <UserX className="w-4 h-4" />
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
+              </Card>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/features/matching/components/MatchingMain.tsx
+++ b/frontend/src/features/matching/components/MatchingMain.tsx
@@ -192,7 +192,7 @@ export default function MatchingMain() {
                 <div className="flex items-center justify-between px-4 py-3.5">
                   <div className="flex items-center gap-3">
                     <div className="w-9 h-9 rounded-full bg-primary/10 flex items-center justify-center font-semibold text-primary text-sm">
-                      {rel.partner.display_name.charAt(0)}
+                      {rel.partner.display_name?.[0]}
                     </div>
                     <div>
                       <p className="text-sm font-medium">{rel.partner.display_name}</p>

--- a/frontend/src/features/settings/components/SettingsMain.tsx
+++ b/frontend/src/features/settings/components/SettingsMain.tsx
@@ -72,11 +72,11 @@ export default function SettingsMain() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="max-w-2xl mx-auto">
-        <div className="flex items-center gap-2 mb-8">
-          <Settings className="w-8 h-8 text-primary" />
-          <h1 className="text-3xl font-bold">設定</h1>
+    <div className="container mx-auto px-4 py-5">
+      <div className="max-w-xl mx-auto">
+        <div className="flex items-center gap-2 mb-5">
+          <Settings className="w-5 h-5 text-primary" />
+          <h1 className="text-xl font-semibold">設定</h1>
         </div>
 
         <form onSubmit={handleSubmit}>
@@ -87,7 +87,7 @@ export default function SettingsMain() {
                 表示名やメールアドレスを変更できます。
               </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-6">
+            <CardContent className="space-y-4">
               {message && (
                 <div
                   className={`p-4 rounded-md text-sm ${
@@ -129,7 +129,7 @@ export default function SettingsMain() {
                 />
               </div>
             </CardContent>
-            <CardFooter className="flex justify-end border-t pt-6">
+            <CardFooter className="flex justify-end border-t pt-4">
               <Button type="submit" disabled={isLoading} className="gap-2">
                 {isLoading ? (
                   <Loader2 className="w-4 h-4 animate-spin" />


### PR DESCRIPTION
## 概要

フロントエンドのUI全面刷新と、ダッシュボードへのバディ連携機能・直近タスク表示を追加。

## 変更内容

### UI刷新

- **カラーパレット**: フォレストグリーン × ウォームクリームのOKLCHカラーに統一
- **ヘッダー**: スティッキー + グラスモーフィズム、`usePathname()` によるアクティブナビ、モバイルメニュー改善
- **認証画面**: デスクトップ2カラムスプリットレイアウト（左: ブランドヒーロー、右: フォーム）、Cardラッパー廃止のクリーンなフォーム
- **ダッシュボード**: Bentoグリッドレイアウト（達成率ヒーローカード + 直近タスク + バディ状況）
- **カード余白**: 全体的にコンパクトに調整
- **レスポンシブ**: 全ページのモバイル対応

### ダッシュボード機能

- **直近の未完了タスク**: 今日以降の未完了タスクを `start_time` 昇順で最大4件表示（時間 + タイトル形式）
- **バディの今日の状況**: アクティブなバディ全員の今日のタイムブロッキングを最大4件表示
- **タイムブロッキング促し**: 自分が今日のタスク未登録の場合、カレンダーへ誘導するバナーを表示
- **バディ数カード削除**: 情報量が少なく冗長だったため除去
- **今日の完了数カード削除**: 「X / Y 件完了」表示を廃止し、直近タスクリストに置き換え

### アクセシビリティ

- `CalendarView` の `DialogContent` に `aria-describedby={undefined}` を追加してRadix UI警告を解消

## コミット構成

1. **`feat(ui): フロントエンドUI全面刷新・ダッシュボード機能追加`** — カラーパレット、ヘッダー、認証画面、Bentoグリッド、バディ状況表示、促しバナー、a11y修正
2. **`refactor(dashboard): バディ数カード削除・直近未完了タスク4件表示・バディタスクを最大4件に変更`** — ダッシュボードの情報整理

## テスト手順

- [ ]  ログイン画面でデスクトップ/モバイル両方のレイアウトを確認
- [ ]  ダッシュボードで今日のタスクを0件にしてバナーが表示されることを確認
- [ ]  ダッシュボードに直近の未完了タスクが最大4件表示されることを確認
- [ ]  アクティブなバディがいる場合、今日のタイムブロッキング状況が最大4件表示されることを確認
- [ ]  カレンダーでAction Itemダイアログを開き、コンソール警告が出ないことを確認
- [ ]  各ページのレスポンシブ表示を確認