### PR TITLE
feat(chat): room_members に last_read_message_id を追加し未読数APIを実装 (#122)

### DIFF
--- a/backend/db/migrations/000006_add_last_read_message_id.down.sql
+++ b/backend/db/migrations/000006_add_last_read_message_id.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE room_members DROP COLUMN IF EXISTS last_read_message_id;

--- a/backend/db/migrations/000006_add_last_read_message_id.up.sql
+++ b/backend/db/migrations/000006_add_last_read_message_id.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE room_members
+  ADD COLUMN last_read_message_id BIGINT REFERENCES messages(id) ON DELETE SET NULL;

--- a/backend/internal/chat/handler.go
+++ b/backend/internal/chat/handler.go
@@ -39,9 +39,10 @@ func (h *Handler) GetRooms(c *gin.Context) {
 		DisplayName string `json:"display_name"`
 	}
 	type roomResponse struct {
-		ID        string      `json:"id"`
-		Partner   partnerInfo `json:"partner"`
-		CreatedAt interface{} `json:"created_at"`
+		ID          string      `json:"id"`
+		Partner     partnerInfo `json:"partner"`
+		CreatedAt   interface{} `json:"created_at"`
+		UnreadCount int         `json:"unread_count"`
 	}
 
 	res := make([]roomResponse, 0, len(rooms))
@@ -52,10 +53,39 @@ func (h *Handler) GetRooms(c *gin.Context) {
 				ID:          r.PartnerID.String(),
 				DisplayName: r.PartnerName,
 			},
-			CreatedAt: r.CreatedAt,
+			CreatedAt:   r.CreatedAt,
+			UnreadCount: r.UnreadCount,
 		})
 	}
 	c.JSON(http.StatusOK, res)
+}
+
+// MarkRoomAsRead PUT /api/rooms/:id/read
+func (h *Handler) MarkRoomAsRead(c *gin.Context) {
+	user, ok := auth.GetCurrentUserFromContext(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "認証が必要です"})
+		return
+	}
+
+	roomID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "不正なID形式です"})
+		return
+	}
+
+	isMember, err := h.roomSvc.IsRoomMember(c.Request.Context(), roomID, user.ID)
+	if err != nil || !isMember {
+		c.JSON(http.StatusForbidden, gin.H{"error": "アクセス権がありません"})
+		return
+	}
+
+	if err := h.roomSvc.UpdateLastRead(c.Request.Context(), roomID, user.ID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "サーバーエラーが発生しました"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"ok": true})
 }
 
 // GetMessages GET /api/rooms/:id/messages

--- a/backend/internal/chat/room/model.go
+++ b/backend/internal/chat/room/model.go
@@ -14,8 +14,9 @@ type Room struct {
 
 // RoomWithPartner はルーム一覧API用（パートナー情報付き）
 type RoomWithPartner struct {
-	ID            uuid.UUID `db:"id"`
-	PartnerID     uuid.UUID `db:"partner_id"`
-	PartnerName   string    `db:"partner_name"`
-	CreatedAt     time.Time `db:"created_at"`
+	ID          uuid.UUID `db:"id"`
+	PartnerID   uuid.UUID `db:"partner_id"`
+	PartnerName string    `db:"partner_name"`
+	CreatedAt   time.Time `db:"created_at"`
+	UnreadCount int       `db:"unread_count"`
 }

--- a/backend/internal/chat/room/room_repository.go
+++ b/backend/internal/chat/room/room_repository.go
@@ -13,4 +13,6 @@ type RoomRepository interface {
 	GetUserRoomIDs(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error)
 	// ユーザーがルームメンバーかチェック
 	IsRoomMember(ctx context.Context, roomID, userID uuid.UUID) (bool, error)
+	// 最終既読メッセージIDを更新
+	UpdateLastRead(ctx context.Context, roomID, userID uuid.UUID) error
 }

--- a/backend/internal/chat/room/room_repository_postgres.go
+++ b/backend/internal/chat/room/room_repository_postgres.go
@@ -21,7 +21,14 @@ func (r *PostgresRepository) GetRoomsByUserID(ctx context.Context, userID uuid.U
 			rm.room_id AS id,
 			partner.user_id AS partner_id,
 			u.display_name AS partner_name,
-			ro.created_at
+			ro.created_at,
+			(
+				SELECT COUNT(*)
+				FROM messages m
+				WHERE m.room_id = rm.room_id
+				  AND m.sender_id != $1
+				  AND (rm.last_read_message_id IS NULL OR m.id > rm.last_read_message_id)
+			) AS unread_count
 		FROM room_members rm
 		INNER JOIN rooms ro ON ro.id = rm.room_id
 		INNER JOIN room_members partner ON partner.room_id = rm.room_id AND partner.user_id != $1
@@ -37,12 +44,21 @@ func (r *PostgresRepository) GetRoomsByUserID(ctx context.Context, userID uuid.U
 	var rooms []*RoomWithPartner
 	for rows.Next() {
 		rp := &RoomWithPartner{}
-		if err := rows.Scan(&rp.ID, &rp.PartnerID, &rp.PartnerName, &rp.CreatedAt); err != nil {
+		if err := rows.Scan(&rp.ID, &rp.PartnerID, &rp.PartnerName, &rp.CreatedAt, &rp.UnreadCount); err != nil {
 			return nil, err
 		}
 		rooms = append(rooms, rp)
 	}
 	return rooms, rows.Err()
+}
+
+func (r *PostgresRepository) UpdateLastRead(ctx context.Context, roomID, userID uuid.UUID) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE room_members
+		SET last_read_message_id = (SELECT MAX(id) FROM messages WHERE room_id = $1)
+		WHERE room_id = $1 AND user_id = $2
+	`, roomID, userID)
+	return err
 }
 
 func (r *PostgresRepository) GetUserRoomIDs(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error) {

--- a/backend/internal/chat/room/room_service.go
+++ b/backend/internal/chat/room/room_service.go
@@ -25,3 +25,7 @@ func (s *RoomService) GetUserRoomIDs(ctx context.Context, userID uuid.UUID) ([]u
 func (s *RoomService) IsRoomMember(ctx context.Context, roomID, userID uuid.UUID) (bool, error) {
 	return s.repo.IsRoomMember(ctx, roomID, userID)
 }
+
+func (s *RoomService) UpdateLastRead(ctx context.Context, roomID, userID uuid.UUID) error {
+	return s.repo.UpdateLastRead(ctx, roomID, userID)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -95,6 +95,7 @@ func main() {
 		// チャット
 		protected.GET("/rooms", chatHandler.GetRooms)
 		protected.GET("/rooms/:id/messages", chatHandler.GetMessages)
+		protected.PUT("/rooms/:id/read", chatHandler.MarkRoomAsRead)
 
 		// バディ
 		buddyGroup := protected.Group("/buddy")


### PR DESCRIPTION
<html><head></head><body><h2>PR: feat(chat): room_members に last_read_message_id を追加し未読数APIを実装 (#122)</h2>
<h3>概要</h3>
<p>チャットの未読メッセージ数を管理するため、<code>room_members</code> テーブルに <code>last_read_message_id</code> カラムを追加し、未読数の取得・既読更新のAPIを実装した。</p>
<h3>変更内容</h3>
<h4>DBマイグレーション</h4>
<ul>
<li><code>000006_add_last_read_message_id</code>: <code>room_members</code> に <code>last_read_message_id BIGINT REFERENCES messages(id) ON DELETE SET NULL</code> を追加</li>
</ul>
<h4>バックエンド</h4>
<ul>
<li><strong>GET /api/rooms</strong> のレスポンスに <code>unread_count</code> を追加
<ul>
<li>自分以外が送信した未読メッセージ数をサブクエリで算出</li>
<li><code>last_read_message_id</code> が NULL の場合（初回）は全メッセージを未読としてカウント</li>
</ul>
</li>
<li><strong>PUT /api/rooms/:id/read</strong> エンドポイントを新規追加
<ul>
<li><code>last_read_message_id</code> をそのルームの最新メッセージIDに更新</li>
<li>ルームメンバーでない場合は 403 を返す</li>
</ul>
</li>
</ul>
<h4>変更ファイル</h4>

ファイル | 内容
-- | --
db/migrations/000006_*.sql | room_members.last_read_message_id 追加
internal/chat/room/model.go | RoomWithPartner に UnreadCount フィールド追加
internal/chat/room/room_repository.go | UpdateLastRead インターフェース追加
internal/chat/room/room_repository_postgres.go | 未読数サブクエリ追加 + UpdateLastRead 実装
internal/chat/room/room_service.go | UpdateLastRead サービスメソッド追加
internal/chat/handler.go | unread_count レスポンス追加 + MarkRoomAsRead ハンドラー追加
main.go | PUT /rooms/:id/read ルート登録


<h3>動作確認</h3>
<pre><code class="language-bash"># マイグレーション適用
make migrate-up

# ルーム一覧取得（unread_count が含まれる）
curl -b "session_token=&lt;token&gt;" &lt;http://localhost:8080/api/rooms&gt;
# → [{"id":"...","partner":{...},"created_at":"...","unread_count":8}, ...]

# 既読更新
curl -X PUT -b "session_token=&lt;token&gt;" &lt;http://localhost:8080/api/rooms/&gt;&lt;room-id&gt;/read
# → {"ok":true}

# 再取得で unread_count が 0 に
curl -b "session_token=&lt;token&gt;" &lt;http://localhost:8080/api/rooms&gt;
# → unread_count: 0（他のルームは影響なし）
</code></pre>
<h3>関連 Issue</h3>
<ul>
<li>closes #122</li>
</ul>
<!-- notionvc: 217a66fc-e1a0-4f89-b352-62bde4abd360 --></body></html>