### PR TITLE
feat(chat): チャット一覧に未読バッジを表示・既読更新を実装 (#123)

### DIFF
--- a/frontend/src/app/(app)/chat/page.tsx
+++ b/frontend/src/app/(app)/chat/page.tsx
@@ -13,19 +13,26 @@ function ChatContent() {
   const searchParams = useSearchParams()
   const [selectedRoomId, setSelectedRoomId] = useState<string | undefined>(undefined)
 
-  const { chatRooms, currentUserId, wsURL, fetchMessages, addMessage, getMessages } = useChat()
+  const { chatRooms, currentUserId, fetchMessages, addMessage, getMessages, markRoomAsRead, setActiveRoom, sendMessage } = useChat()
 
   useEffect(() => {
     const roomParam = searchParams.get('room')
     if (roomParam) {
       setSelectedRoomId(roomParam)
       fetchMessages(roomParam)
+      markRoomAsRead(roomParam)
     }
   }, [searchParams])
+
+  // アクティブルームの同期
+  useEffect(() => {
+    setActiveRoom(selectedRoomId)
+  }, [selectedRoomId, setActiveRoom])
 
   const handleSelectRoom = (roomId: string) => {
     setSelectedRoomId(roomId)
     fetchMessages(roomId)
+    markRoomAsRead(roomId)
   }
 
   const selectedRoom = chatRooms.find((r) => r.id === selectedRoomId)
@@ -64,8 +71,7 @@ function ChatContent() {
                 participantName={selectedRoom.participantName}
                 messages={messages}
                 currentUserId={currentUserId}
-                onReceiveMessage={addMessage}
-                wsURL={wsURL}
+                onSendMessage={sendMessage}
               />
             </div>
           ) : (

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -19,8 +19,7 @@ interface ChatWindowProps {
   participantName: string
   messages: Message[]
   currentUserId: string | null
-  onReceiveMessage: (data: string) => void
-  wsURL: string
+  onSendMessage: (roomId: string, content: string) => void
 }
 
 export function ChatWindow({
@@ -28,43 +27,19 @@ export function ChatWindow({
   participantName,
   messages,
   currentUserId,
-  onReceiveMessage,
-  wsURL,
+  onSendMessage,
 }: ChatWindowProps) {
   const [inputValue, setInputValue] = useState('')
   const messagesEndRef = useRef<HTMLDivElement>(null)
-  const wsRef = useRef<WebSocket | null>(null)
-  const onReceiveMessageRef = useRef(onReceiveMessage)
-
-  useEffect(() => {
-    onReceiveMessageRef.current = onReceiveMessage
-  }, [onReceiveMessage])
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
 
-  useEffect(() => {
-    const ws = new WebSocket(wsURL)
-    wsRef.current = ws
-
-    ws.onopen = () => console.log('WebSocket opened')
-    ws.onmessage = (event) => onReceiveMessageRef.current(event.data)
-    ws.onclose = () => console.log('WebSocket disconnected')
-
-    return () => ws.close()
-  }, [wsURL])
-
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (!inputValue.trim() || !wsRef.current) return
-
-    wsRef.current.send(
-      JSON.stringify({
-        room_id: roomId,
-        content: inputValue.trim(),
-      }),
-    )
+    if (!inputValue.trim()) return
+    onSendMessage(roomId, inputValue.trim())
     setInputValue('')
   }
 

--- a/frontend/src/features/chat/hooks/useChat.ts
+++ b/frontend/src/features/chat/hooks/useChat.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { Message, ChatRoom } from '../types/chat'
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080'
@@ -15,6 +15,9 @@ export function useChat(initialRoomId?: string) {
   const [chatRooms, setChatRooms] = useState<ChatRoom[]>([])
   const [messages, setMessages] = useState<Record<string, Message[]>>({})
   const [currentUserId, setCurrentUserId] = useState<string | null>(null)
+  const activeRoomIdRef = useRef<string | undefined>(undefined)
+  const wsRef = useRef<WebSocket | null>(null)
+  const addMessageRef = useRef<(data: string) => void>(() => {})
 
   // 現在のユーザーIDを取得
   useEffect(() => {
@@ -28,14 +31,18 @@ export function useChat(initialRoomId?: string) {
   const fetchRooms = useCallback(async () => {
     const res = await fetch(`${API_BASE}/api/rooms`, { credentials: 'include' })
     if (!res.ok) return
-    const data: Array<{ id: string; partner: { id: string; display_name: string }; created_at: string }> =
-      await res.json()
+    const data: Array<{
+      id: string
+      partner: { id: string; display_name: string }
+      created_at: string
+      unread_count: number
+    }> = await res.json()
     setChatRooms(
       data.map((r) => ({
         id: r.id,
         participantId: r.partner.id,
         participantName: r.partner.display_name,
-        unreadCount: 0,
+        unreadCount: r.unread_count,
       })),
     )
   }, [])
@@ -98,27 +105,76 @@ export function useChat(initialRoomId?: string) {
           ...prev,
           [msg.room_id]: [...(prev[msg.room_id] ?? []), newMessage],
         }))
+
+        // 非アクティブルームかつ自分以外の送信なら未読数をインクリメント
+        if (msg.room_id !== activeRoomIdRef.current && msg.sender_id !== currentUserId) {
+          setChatRooms((prev) =>
+            prev.map((r) =>
+              r.id === msg.room_id ? { ...r, unreadCount: r.unreadCount + 1 } : r,
+            ),
+          )
+        }
       } catch {
         // parse error は無視
       }
     },
-    [],
+    [currentUserId],
   )
+
+  // addMessage の最新版を ref で保持（WebSocket の onmessage から参照）
+  useEffect(() => {
+    addMessageRef.current = addMessage
+  }, [addMessage])
+
+  // WebSocket 接続（チャットページを開いている間は常に接続）
+  useEffect(() => {
+    const token = getSessionToken()
+    const url = `${WS_BASE}/ws${token ? `?token=${token}` : ''}`
+    const ws = new WebSocket(url)
+    wsRef.current = ws
+
+    ws.onopen = () => console.log('WebSocket opened')
+    ws.onmessage = (event) => addMessageRef.current(event.data)
+    ws.onclose = () => console.log('WebSocket disconnected')
+
+    return () => ws.close()
+  }, [])
 
   const getMessages = useCallback(
     (roomId: string) => messages[roomId] ?? [],
     [messages],
   )
 
-  const token = getSessionToken()
-  const wsURL = `${WS_BASE}/ws${token ? `?token=${token}` : ''}`
+  // アクティブルームを設定（未読カウント制御用）
+  const setActiveRoom = useCallback((roomId: string | undefined) => {
+    activeRoomIdRef.current = roomId
+  }, [])
+
+  // 既読更新
+  const markRoomAsRead = useCallback(async (roomId: string) => {
+    await fetch(`${API_BASE}/api/rooms/${roomId}/read`, {
+      method: 'PUT',
+      credentials: 'include',
+    })
+    setChatRooms((prev) =>
+      prev.map((r) => (r.id === roomId ? { ...r, unreadCount: 0 } : r)),
+    )
+  }, [])
+
+  // メッセージ送信
+  const sendMessage = useCallback((roomId: string, content: string) => {
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return
+    wsRef.current.send(JSON.stringify({ room_id: roomId, content }))
+  }, [])
 
   return {
     chatRooms,
     currentUserId,
-    wsURL,
     fetchMessages,
     addMessage,
     getMessages,
+    markRoomAsRead,
+    setActiveRoom,
+    sendMessage,
   }
 }

--- a/frontend/src/features/chat/hooks/useChat.ts
+++ b/frontend/src/features/chat/hooks/useChat.ts
@@ -79,6 +79,17 @@ export function useChat(initialRoomId?: string) {
     }))
   }, [])
 
+  // 既読更新（addMessage より前に定義）
+  const markRoomAsRead = useCallback(async (roomId: string) => {
+    await fetch(`${API_BASE}/api/rooms/${roomId}/read`, {
+      method: 'PUT',
+      credentials: 'include',
+    })
+    setChatRooms((prev) =>
+      prev.map((r) => (r.id === roomId ? { ...r, unreadCount: 0 } : r)),
+    )
+  }, [])
+
   // WebSocket からのメッセージを受信して state に反映
   const addMessage = useCallback(
     (data: string) => {
@@ -106,19 +117,25 @@ export function useChat(initialRoomId?: string) {
           [msg.room_id]: [...(prev[msg.room_id] ?? []), newMessage],
         }))
 
-        // 非アクティブルームかつ自分以外の送信なら未読数をインクリメント
-        if (msg.room_id !== activeRoomIdRef.current && msg.sender_id !== currentUserId) {
-          setChatRooms((prev) =>
-            prev.map((r) =>
-              r.id === msg.room_id ? { ...r, unreadCount: r.unreadCount + 1 } : r,
-            ),
-          )
+        // currentUserId が未取得の間は判定をスキップ
+        if (currentUserId && msg.sender_id !== currentUserId) {
+          if (msg.room_id === activeRoomIdRef.current) {
+            // アクティブルームの新着はサーバー側の既読状態を更新
+            markRoomAsRead(msg.room_id)
+          } else {
+            // 非アクティブルームは未読数をインクリメント
+            setChatRooms((prev) =>
+              prev.map((r) =>
+                r.id === msg.room_id ? { ...r, unreadCount: r.unreadCount + 1 } : r,
+              ),
+            )
+          }
         }
       } catch {
         // parse error は無視
       }
     },
-    [currentUserId],
+    [currentUserId, markRoomAsRead],
   )
 
   // addMessage の最新版を ref で保持（WebSocket の onmessage から参照）
@@ -148,17 +165,6 @@ export function useChat(initialRoomId?: string) {
   // アクティブルームを設定（未読カウント制御用）
   const setActiveRoom = useCallback((roomId: string | undefined) => {
     activeRoomIdRef.current = roomId
-  }, [])
-
-  // 既読更新
-  const markRoomAsRead = useCallback(async (roomId: string) => {
-    await fetch(`${API_BASE}/api/rooms/${roomId}/read`, {
-      method: 'PUT',
-      credentials: 'include',
-    })
-    setChatRooms((prev) =>
-      prev.map((r) => (r.id === roomId ? { ...r, unreadCount: 0 } : r)),
-    )
   }, [])
 
   // メッセージ送信


### PR DESCRIPTION
<html><head></head><body><h2>PR: feat(chat): チャット一覧に未読バッジを表示・既読更新を実装 (#123)</h2>
<h3>概要</h3>
<p>チャット一覧の未読バッジ表示、ルーム選択時の既読更新、WebSocket経由のリアルタイム未読インクリメントを実装。また、WebSocket接続をChatWindowからuseChatフックに移動し、チャットページを開いている間は全ルームのメッセージを受信できるようにした。</p>
<h3>変更内容</h3>
<h4>useChat.ts（チャットフック）</h4>
<ul>
<li><strong>未読数マッピング</strong>: <code>fetchRooms</code> で API の <code>unread_count</code> を <code>ChatRoom.unreadCount</code> にマッピング（従来はハードコード <code>0</code>）</li>
<li><strong>WebSocket接続をフックに移動</strong>: ChatWindow内ではなくuseChat内でWebSocket接続を管理。チャットページを開いた瞬間から全ルームのメッセージを受信可能に</li>
<li><strong>リアルタイム未読インクリメント</strong>: 非アクティブルームかつ自分以外の送信者からのメッセージ受信時に <code>unreadCount</code> を +1</li>
<li><strong><code>markRoomAsRead</code></strong>: <code>PUT /api/rooms/:id/read</code> を呼び出し + ローカル state の <code>unreadCount</code> を即座に 0 にリセット</li>
<li><strong><code>setActiveRoom</code></strong>: <code>activeRoomIdRef</code> を更新（未読インクリメントの制御用）</li>
<li><strong><code>sendMessage</code></strong>: <code>wsRef</code> 経由でメッセージ送信（ChatWindow から WebSocket を分離）</li>
</ul>
<h4>ChatWindow.tsx</h4>
<ul>
<li>WebSocket 関連コード（<code>wsRef</code>, <code>onReceiveMessageRef</code>, 接続/切断処理）を<strong>すべて削除</strong></li>
<li><code>onReceiveMessage</code> + <code>wsURL</code> props → <code>onSendMessage</code> prop に変更</li>
</ul>
<h4>chat/page.tsx</h4>
<ul>
<li><code>useChat</code> の返り値から <code>wsURL</code> を削除、<code>sendMessage</code> を追加</li>
<li>ルーム選択時（クリック / URL <code>?room=</code> パラメータ）に <code>markRoomAsRead</code> を呼び出し</li>
<li><code>selectedRoomId</code> 変化時に <code>setActiveRoom</code> を同期</li>
</ul>
<h3>変更ファイル</h3>

ファイル | 内容
-- | --
features/chat/hooks/useChat.ts | WebSocket移動、未読マッピング、markRoomAsRead / setActiveRoom / sendMessage 追加
features/chat/components/ChatWindow.tsx | WebSocket削除、onSendMessage prop化
app/(app)/chat/page.tsx | 既読更新・アクティブルーム同期・sendMessage連携


<h3>アーキテクチャ変更: WebSocket の責務移動</h3>
<pre><code>【変更前】
chat/page.tsx → ChatWindow（WebSocket接続・送受信）
  → ルームを選択しないとWebSocket未接続
  → 他ルームのメッセージを受信できない

【変更後】
chat/page.tsx → useChat（WebSocket接続・受信・未読管理）
                  → ChatWindow（送信のみ、onSendMessage経由）
  → ページを開いた瞬間にWebSocket接続
  → 全ルームのメッセージをリアルタイム受信
  → 非アクティブルームの未読数を自動インクリメント
</code></pre>
<h3>テスト手順</h3>
<ul>
<li>[ ]  <code>/chat</code> を開き、ルーム一覧に未読バッジ（数字）が表示されることを確認</li>
<li>[ ]  ルームをクリックするとバッジが消えることを確認</li>
<li>[ ]  別アカウントでメッセージを送信し、別ルームにいる状態でバッジがリアルタイムで増えることを確認</li>
<li>[ ]  URL <code>?room=&lt;id&gt;</code> 経由でアクセスした場合も既読更新されることを確認</li>
<li>[ ]  メッセージの送受信が正常に動作することを確認</li>
</ul>
<h3>関連 Issue</h3>
<ul>
<li>closes #123</li>
<li>depends on #122（<code>last_read_message_id</code> カラム + 未読数 API）</li>
</ul>
<!-- notionvc: 7b16985b-1a66-439f-aa17-fa4130d48442 --></body></html>


<html><head></head><body><p>PRに追加する文章：</p>
<hr>
<h3>レビュー対応: アクティブルームの既読状態がサーバーに反映されない問題を修正</h3>
<p><strong>指摘 (@gemini-code-assist, high)</strong></p>
<p>アクティブなルームでメッセージを受信した際にサーバー側の既読状態（<code>last_read_message_id</code>）が更新されないため、リロードすると未読バッジが再表示されてしまう。また、<code>currentUserId</code> が未取得の状態でメッセージを受信した場合の考慮も必要。</p>
<p><strong>修正内容</strong></p>

変更 | 理由
-- | --
markRoomAsRead を addMessage より前に定義 | addMessage の deps に追加するため
currentUserId && ... でガード追加 | null の間は自分のメッセージかどうかの判定が不正確になるため
アクティブルームの新着メッセージ受信時に markRoomAsRead を呼び出し | リロード後に未読バッジが再表示されるバグを修正
addMessage の deps に markRoomAsRead を追加 | 最新の関数を参照するため


<p><strong>修正前:</strong></p>
<pre><code class="language-tsx">// 非アクティブルームかつ自分以外の送信なら未読数をインクリメント
if (msg.room_id !== activeRoomIdRef.current &amp;&amp; msg.sender_id !== currentUserId) {
  setChatRooms((prev) =&gt; prev.map((r) =&gt;
    r.id === msg.room_id ? { ...r, unreadCount: r.unreadCount + 1 } : r,
  ))
}
</code></pre>
<p><strong>修正後:</strong></p>
<pre><code class="language-tsx">// currentUserId が未取得の間は判定をスキップ
if (currentUserId &amp;&amp; msg.sender_id !== currentUserId) {
  if (msg.room_id === activeRoomIdRef.current) {
    // アクティブルームの新着はサーバー側の既読状態を更新
    markRoomAsRead(msg.room_id)
  } else {
    // 非アクティブルームは未読数をインクリメント
    setChatRooms((prev) =&gt; prev.map((r) =&gt;
      r.id === msg.room_id ? { ...r, unreadCount: r.unreadCount + 1 } : r,
    ))
  }
}
</code></pre>
<!-- notionvc: 4c4fd163-b277-408e-a3ed-3d015385c6dc --></body></html>