### PR TITLE
feat(chat): ヘッダーのチャットアイコンに総未読数バッジを表示 (#124)

### DIFF
--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -57,6 +57,11 @@ export function Header() {
 	}, []);
 
 	useEffect(() => {
+		if (!currentUser) {
+			setTotalUnread(0);
+			return;
+		}
+
 		const fetchUnread = () => {
 			fetch(`${API_BASE_URL}/api/rooms`, { credentials: "include" })
 				.then((res) => (res.ok ? res.json() : []))
@@ -76,7 +81,7 @@ export function Header() {
 			window.removeEventListener("chat:read", fetchUnread);
 			window.removeEventListener("chat:unread", fetchUnread);
 		};
-	}, [pathname]);
+	}, [pathname, currentUser]);
 
 	const handleLogout = async () => {
 		await fetch(`${API_BASE_URL}/api/auth/logout`, {

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -70,9 +70,11 @@ export function Header() {
 		fetchUnread();
 		const interval = setInterval(fetchUnread, 30000);
 		window.addEventListener("chat:read", fetchUnread);
+		window.addEventListener("chat:unread", fetchUnread);
 		return () => {
 			clearInterval(interval);
 			window.removeEventListener("chat:read", fetchUnread);
+			window.removeEventListener("chat:unread", fetchUnread);
 		};
 	}, [pathname]);
 

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -1,198 +1,239 @@
-'use client'
+"use client";
 
-import { useState, useEffect } from 'react'
-import Link from 'next/link'
-import { Button } from '@/components/ui/button'
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
-  Users,
-  Calendar,
-  Bell,
-  Mail,
-  LogOut,
-  Settings,
-  UserCircle,
-  Menu,
-  X,
-} from 'lucide-react'
-import type { LucideIcon } from 'lucide-react'
-import { useCurrentUser } from '@/features/auth/hooks/useCurrentUser'
-import { useRouter, usePathname } from 'next/navigation'
+	Users,
+	Calendar,
+	Bell,
+	Mail,
+	LogOut,
+	Settings,
+	UserCircle,
+	Menu,
+	X,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useCurrentUser } from "@/features/auth/hooks/useCurrentUser";
+import { useRouter, usePathname } from "next/navigation";
 
 interface NavItem {
-  href: string
-  label: string
-  icon: LucideIcon
+	href: string;
+	label: string;
+	icon: LucideIcon;
 }
 
 const NAV_ITEMS: NavItem[] = [
-  { href: '/calendar',  label: 'カレンダー', icon: Calendar  },
-  { href: '/buddies',   label: 'バディ',     icon: UserCircle },
-  { href: '/matching',  label: 'マッチング', icon: Users      },
-]
+	{ href: "/calendar", label: "カレンダー", icon: Calendar },
+	{ href: "/buddies", label: "バディ", icon: UserCircle },
+	{ href: "/matching", label: "マッチング", icon: Users },
+];
 
-const MOCK_NOTIFICATION_COUNT = 0
+const MOCK_NOTIFICATION_COUNT = 0;
 
 const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080'
+	process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
 
 export function Header() {
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
-  const [mounted, setMounted] = useState(false)
-  const router   = useRouter()
-  const pathname = usePathname()
+	const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+	const [mounted, setMounted] = useState(false);
+	const [totalUnread, setTotalUnread] = useState(0);
+	const router = useRouter();
+	const pathname = usePathname();
 
-  const { user: currentUser } = useCurrentUser()
+	const { user: currentUser } = useCurrentUser();
 
-  useEffect(() => { setMounted(true) }, [])
+	useEffect(() => {
+		setMounted(true);
+	}, []);
 
-  const handleLogout = async () => {
-    await fetch(`${API_BASE_URL}/api/auth/logout`, {
-      method: 'POST',
-      credentials: 'include',
-    })
-    document.cookie = 'session_token=; path=/; max-age=0'
-    sessionStorage.removeItem('session_token')
-    router.push('/login')
-  }
+	useEffect(() => {
+		const fetchUnread = () => {
+			fetch(`${API_BASE_URL}/api/rooms`, { credentials: "include" })
+				.then((res) => (res.ok ? res.json() : []))
+				.then((data: Array<{ unread_count: number }>) => {
+					setTotalUnread(
+						data.reduce((sum, r) => sum + (r.unread_count ?? 0), 0),
+					);
+				})
+				.catch(() => {});
+		};
+		fetchUnread();
+		const interval = setInterval(fetchUnread, 30000);
+		window.addEventListener("chat:read", fetchUnread);
+		return () => {
+			clearInterval(interval);
+			window.removeEventListener("chat:read", fetchUnread);
+		};
+	}, [pathname]);
 
-  return (
-    <>
-      {isMobileMenuOpen && (
-        <div
-          className="fixed inset-0 z-10 bg-black/30 backdrop-blur-sm md:hidden"
-          onClick={() => setIsMobileMenuOpen(false)}
-        />
-      )}
+	const handleLogout = async () => {
+		await fetch(`${API_BASE_URL}/api/auth/logout`, {
+			method: "POST",
+			credentials: "include",
+		});
+		document.cookie = "session_token=; path=/; max-age=0";
+		sessionStorage.removeItem("session_token");
+		router.push("/login");
+	};
 
-      <header className="sticky top-0 z-20 h-14 bg-background/80 backdrop-blur-xl border-b border-border/50">
-        <div className="max-w-6xl mx-auto px-4 h-full flex items-center justify-between">
+	return (
+		<>
+			{isMobileMenuOpen && (
+				<div
+					className="fixed inset-0 z-10 bg-black/30 backdrop-blur-sm md:hidden"
+					onClick={() => setIsMobileMenuOpen(false)}
+				/>
+			)}
 
-          {/* Logo */}
-          <Link href="/dashboard" className="flex items-center gap-2 shrink-0">
-            <div className="w-7 h-7 bg-primary rounded-lg flex items-center justify-center shadow-sm">
-              <Users className="w-4 h-4 text-primary-foreground" />
-            </div>
-            <span className="font-semibold text-sm tracking-tight">ActBuddy</span>
-          </Link>
+			<header className="sticky top-0 z-20 h-14 bg-background/80 backdrop-blur-xl border-b border-border/50">
+				<div className="max-w-6xl mx-auto px-4 h-full flex items-center justify-between">
+					{/* Logo */}
+					<Link href="/dashboard" className="flex items-center gap-2 shrink-0">
+						<div className="w-7 h-7 bg-primary rounded-lg flex items-center justify-center shadow-sm">
+							<Users className="w-4 h-4 text-primary-foreground" />
+						</div>
+						<span className="font-semibold text-sm tracking-tight">
+							ActBuddy
+						</span>
+					</Link>
 
-          {/* Desktop Nav */}
-          <nav className="hidden md:flex items-center gap-0.5">
-            {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
-              const active = pathname.startsWith(href)
-              return (
-                <Link
-                  key={href}
-                  href={href}
-                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm transition-colors ${
-                    active
-                      ? 'bg-primary/10 text-primary font-medium'
-                      : 'text-muted-foreground hover:text-foreground hover:bg-accent'
-                  }`}
-                >
-                  <Icon className="w-3.5 h-3.5" />
-                  {label}
-                </Link>
-              )
-            })}
-          </nav>
+					{/* Desktop Nav */}
+					<nav className="hidden md:flex items-center gap-0.5">
+						{NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+							const active = pathname.startsWith(href);
+							return (
+								<Link
+									key={href}
+									href={href}
+									className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm transition-colors ${
+										active
+											? "bg-primary/10 text-primary font-medium"
+											: "text-muted-foreground hover:text-foreground hover:bg-accent"
+									}`}
+								>
+									<Icon className="w-3.5 h-3.5" />
+									{label}
+								</Link>
+							);
+						})}
+					</nav>
 
-          {/* Right */}
-          <div className="flex items-center gap-1">
-            {/* Notifications */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button className="relative p-2 rounded-lg hover:bg-accent transition-colors">
-                  <Bell className="w-4 h-4" />
-                  {MOCK_NOTIFICATION_COUNT > 0 && (
-                    <span className="absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full" />
-                  )}
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
-                <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
-                  {MOCK_NOTIFICATION_COUNT === 0 ? '通知はありません' : `${MOCK_NOTIFICATION_COUNT}件の通知`}
-                </DropdownMenuLabel>
-              </DropdownMenuContent>
-            </DropdownMenu>
+					{/* Right */}
+					<div className="flex items-center gap-1">
+						{/* Notifications */}
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<button className="relative p-2 rounded-lg hover:bg-accent transition-colors">
+									<Bell className="w-4 h-4" />
+									{MOCK_NOTIFICATION_COUNT > 0 && (
+										<span className="absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full" />
+									)}
+								</button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end" className="w-56">
+								<DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+									{MOCK_NOTIFICATION_COUNT === 0
+										? "通知はありません"
+										: `${MOCK_NOTIFICATION_COUNT}件の通知`}
+								</DropdownMenuLabel>
+							</DropdownMenuContent>
+						</DropdownMenu>
 
-            {/* Chat */}
-            <Link href="/chat" className="p-2 rounded-lg hover:bg-accent transition-colors">
-              <Mail className="w-4 h-4" />
-            </Link>
+						{/* Chat */}
+						<Link
+							href="/chat"
+							className="relative p-2 rounded-lg hover:bg-accent transition-colors"
+						>
+							<Mail className="w-4 h-4" />
+							{totalUnread > 0 && (
+								<span className="absolute -top-1 -right-1 min-w-[16px] h-4 bg-red-400 text-white text-[10px] font-bold rounded-full flex items-center justify-center px-1 leading-none">
+									{totalUnread > 99 ? "99+" : totalUnread}
+								</span>
+							)}
+						</Link>
 
-            {/* User */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button className="w-7 h-7 rounded-full bg-primary/15 text-primary flex items-center justify-center text-xs font-semibold hover:bg-primary/25 transition-colors ml-1">
-                  {mounted ? (currentUser?.display_name?.[0] ?? '?') : '?'}
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-44">
-                <DropdownMenuLabel className="text-xs font-normal text-muted-foreground truncate">
-                  {mounted ? (currentUser?.display_name ?? '') : ''}
-                </DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem asChild>
-                  <Link href="/settings" className="flex items-center gap-2 cursor-pointer">
-                    <Settings className="w-3.5 h-3.5" />
-                    設定
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  className="text-destructive focus:text-destructive gap-2"
-                  onClick={handleLogout}
-                >
-                  <LogOut className="w-3.5 h-3.5" />
-                  ログアウト
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+						{/* User */}
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<button className="w-7 h-7 rounded-full bg-primary/15 text-primary flex items-center justify-center text-xs font-semibold hover:bg-primary/25 transition-colors ml-1">
+									{mounted ? (currentUser?.display_name?.[0] ?? "?") : "?"}
+								</button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end" className="w-44">
+								<DropdownMenuLabel className="text-xs font-normal text-muted-foreground truncate">
+									{mounted ? (currentUser?.display_name ?? "") : ""}
+								</DropdownMenuLabel>
+								<DropdownMenuSeparator />
+								<DropdownMenuItem asChild>
+									<Link
+										href="/settings"
+										className="flex items-center gap-2 cursor-pointer"
+									>
+										<Settings className="w-3.5 h-3.5" />
+										設定
+									</Link>
+								</DropdownMenuItem>
+								<DropdownMenuSeparator />
+								<DropdownMenuItem
+									className="text-destructive focus:text-destructive gap-2"
+									onClick={handleLogout}
+								>
+									<LogOut className="w-3.5 h-3.5" />
+									ログアウト
+								</DropdownMenuItem>
+							</DropdownMenuContent>
+						</DropdownMenu>
 
-            {/* Mobile hamburger */}
-            <button
-              className="md:hidden p-2 rounded-lg hover:bg-accent transition-colors ml-1"
-              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-            >
-              {isMobileMenuOpen ? <X className="w-4 h-4" /> : <Menu className="w-4 h-4" />}
-            </button>
-          </div>
-        </div>
+						{/* Mobile hamburger */}
+						<button
+							className="md:hidden p-2 rounded-lg hover:bg-accent transition-colors ml-1"
+							onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+						>
+							{isMobileMenuOpen ? (
+								<X className="w-4 h-4" />
+							) : (
+								<Menu className="w-4 h-4" />
+							)}
+						</button>
+					</div>
+				</div>
 
-        {/* Mobile menu */}
-        {isMobileMenuOpen && (
-          <div className="md:hidden absolute top-14 left-0 right-0 bg-card/95 backdrop-blur-xl border-b border-border/50 shadow-lg">
-            <nav className="max-w-6xl mx-auto px-4 py-3 flex flex-col gap-1">
-              {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
-                const active = pathname.startsWith(href)
-                return (
-                  <Link
-                    key={href}
-                    href={href}
-                    className={`flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-sm transition-colors ${
-                      active
-                        ? 'bg-primary/10 text-primary font-medium'
-                        : 'text-muted-foreground hover:text-foreground hover:bg-accent'
-                    }`}
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    <Icon className="w-4 h-4" />
-                    {label}
-                  </Link>
-                )
-              })}
-            </nav>
-          </div>
-        )}
-      </header>
-    </>
-  )
+				{/* Mobile menu */}
+				{isMobileMenuOpen && (
+					<div className="md:hidden absolute top-14 left-0 right-0 bg-card/95 backdrop-blur-xl border-b border-border/50 shadow-lg">
+						<nav className="max-w-6xl mx-auto px-4 py-3 flex flex-col gap-1">
+							{NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+								const active = pathname.startsWith(href);
+								return (
+									<Link
+										key={href}
+										href={href}
+										className={`flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-sm transition-colors ${
+											active
+												? "bg-primary/10 text-primary font-medium"
+												: "text-muted-foreground hover:text-foreground hover:bg-accent"
+										}`}
+										onClick={() => setIsMobileMenuOpen(false)}
+									>
+										<Icon className="w-4 h-4" />
+										{label}
+									</Link>
+								);
+							})}
+						</nav>
+					</div>
+				)}
+			</header>
+		</>
+	);
 }

--- a/frontend/src/features/chat/hooks/useChat.ts
+++ b/frontend/src/features/chat/hooks/useChat.ts
@@ -130,6 +130,7 @@ export function useChat(initialRoomId?: string) {
                 r.id === msg.room_id ? { ...r, unreadCount: r.unreadCount + 1 } : r,
               ),
             )
+            window.dispatchEvent(new Event('chat:unread'))
           }
         }
       } catch {

--- a/frontend/src/features/chat/hooks/useChat.ts
+++ b/frontend/src/features/chat/hooks/useChat.ts
@@ -88,6 +88,7 @@ export function useChat(initialRoomId?: string) {
     setChatRooms((prev) =>
       prev.map((r) => (r.id === roomId ? { ...r, unreadCount: 0 } : r)),
     )
+    window.dispatchEvent(new Event('chat:read'))
   }, [])
 
   // WebSocket からのメッセージを受信して state に反映


### PR DESCRIPTION
<html><head></head><body><h2>PR: feat(chat): ヘッダーのチャットアイコンに総未読数バッジを表示 (#124)</h2>
<h3>概要</h3>
<p>ヘッダーのチャットアイコン（Mail）に全ルームの未読数を合算したバッジを表示。どのページにいてもチャットの未読状況が一目でわかるようになった。</p>
<h3>背景</h3>
<p>#122（バックエンド未読API）→ #123（チャット一覧の未読バッジ）で、チャット画面内では未読が見えるようになった。しかし、カレンダーやダッシュボードなど <strong>チャット画面以外のページではメッセージの新着に気づけない</strong> 問題が残っていた。</p>
<h3>変更内容</h3>
<h4>Header.tsx</h4>
<ul>
<li><strong><code>totalUnread</code> state を追加</strong>: <code>GET /api/rooms</code> から全ルームの <code>unread_count</code> を合算</li>
<li><strong>バッジ表示</strong>: <code>totalUnread &gt; 0</code> のとき Mail アイコンの右上に赤バッジを表示（99+ 上限あり）</li>
<li><strong>3つのトリガーで更新</strong>:
<ol>
<li><strong>ページ遷移時</strong>: <code>pathname</code> を deps に入れることで、ページ移動のたびに <code>fetchUnread</code> を実行</li>
<li><strong>30秒ポーリング</strong>: <code>setInterval(fetchUnread, 30000)</code> で定期的にサーバーから最新の未読数を取得</li>
<li><strong><code>chat:read</code> カスタムイベント</strong>: チャット画面で既読更新が行われた瞬間に即座に反映</li>
</ol>
</li>
</ul>
<h4>useChat.ts</h4>
<ul>
<li><strong><code>markRoomAsRead</code> 内で <code>chat:read</code> カスタムイベントを発行</strong>: <code>window.dispatchEvent(new Event('chat:read'))</code> を1行追加</li>
</ul>
<h3>Header ↔ useChat の連携の仕組み</h3>
<pre><code>Header（どのページでも表示）          useChat（チャットページのみ）
  │                                      │
  │  useEffect([pathname])               │
  │  ├─ fetchUnread() ─── GET /api/rooms │
  │  ├─ setInterval(30s)                 │
  │  └─ addEventListener('chat:read')    │
  │         ↑                            │
  │         │    カスタムイベント          │
  │         └──────────────────── window.dispatchEvent('chat:read')
  │                                      │
  │                              markRoomAsRead() 実行時に発火
</code></pre>
<p><strong>なぜカスタムイベントを使ったのか:</strong></p>
<p>Header と useChat は親子関係にない独立したコンポーネント/フック。props や Context で繋ぐには大きな設計変更が必要になる。<code>window</code> のカスタムイベントなら、1行の <code>dispatchEvent</code> と1行の <code>addEventListener</code> だけで疎結合に連携できる。</p>
<h3>変更ファイル</h3>

ファイル | 内容
-- | --
components/layouts/Header.tsx | totalUnread state 追加、バッジ表示、3トリガー更新ロジック
features/chat/hooks/useChat.ts | markRoomAsRead に chat:read イベント発行を1行追加


<h3>テスト手順</h3>
<ul>
<li>[ ]  チャット以外のページ（ダッシュボード等）でヘッダーのチャットアイコンに未読数バッジが表示されることを確認</li>
<li>[ ]  未読がない場合はバッジが表示されないことを確認</li>
<li>[ ]  チャット画面でルームを開いて既読にした後、バッジの数値が即座に減ることを確認</li>
<li>[ ]  別アカウントでメッセージを送信し、30秒以内にバッジが更新されることを確認</li>
<li>[ ]  別ページに遷移するとバッジが最新値に更新されることを確認</li>
<li>[ ]  未読数が100以上の場合「99+」と表示されることを確認</li>
</ul>
<h3>今後の改善（スコープ外）</h3>
<p>現在はポーリング + ページ遷移で更新しているため、チャットページ以外ではリアルタイム性に最大30秒のラグがある。将来的にはアプリ全体で WebSocket を常時接続し、LINE/Discord のように即時反映する設計への移行を検討（別 Issue）。</p>
<h3>関連 Issue</h3>
<ul>
<li>closes #124</li>
<li>depends on #122（<code>unread_count</code> API）, #123（チャット一覧未読バッジ）</li>
</ul>
<!-- notionvc: fe65a3c9-f72a-47fb-a24f-7000bedbd3dc --></body></html>